### PR TITLE
Align RSI settings with timeframe recommendations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,9 +47,23 @@ const TIMEFRAMES: TimeframeOption[] = [
   { value: '30', label: '30m' },
   { value: '60', label: '60m' },
   { value: '120', label: '120m' },
-  { value: '240', label: '240m' },
-  { value: '360', label: '360m' },
+  { value: '240', label: '240m (4h)' },
+  { value: '360', label: '360m (6h)' },
+  { value: '420', label: '420m (7h)' },
 ]
+
+const RSI_SETTINGS: Record<string, { period: number; label: string }> = {
+  '5': { period: 8, label: '7–9' },
+  '15': { period: 11, label: '9–12' },
+  '30': { period: 13, label: '12–14' },
+  '60': { period: 15, label: '14–16' },
+  '120': { period: 17, label: '16–18' },
+  '240': { period: 20, label: '18–21' },
+  '360': { period: 23, label: '21–24' },
+  '420': { period: 26, label: '24–28' },
+}
+
+const DEFAULT_RSI_SETTING = { period: 14, label: '14' }
 
 const REFRESH_OPTIONS: RefreshOption[] = [
   { value: '5', label: '5m' },
@@ -265,8 +279,26 @@ function App() {
 
   const closes = useMemo(() => (data ? data.map((candle) => candle.close) : []), [data])
 
-  const rsiValues = useMemo(() => calculateRSI(closes), [closes])
-  const stochasticValues = useMemo(() => calculateStochasticRSI(rsiValues), [rsiValues])
+  const rsiSetting = useMemo(
+    () => RSI_SETTINGS[timeframe] ?? DEFAULT_RSI_SETTING,
+    [timeframe],
+  )
+
+  const rsiLengthDescription = useMemo(() => {
+    if (rsiSetting.label === String(rsiSetting.period)) {
+      return `${rsiSetting.period}`
+    }
+    return `${rsiSetting.period} • range ${rsiSetting.label}`
+  }, [rsiSetting.label, rsiSetting.period])
+
+  const rsiValues = useMemo(
+    () => calculateRSI(closes, rsiSetting.period),
+    [closes, rsiSetting.period],
+  )
+  const stochasticValues = useMemo(
+    () => calculateStochasticRSI(rsiValues, rsiSetting.period),
+    [rsiValues, rsiSetting.period],
+  )
 
   const labels = useMemo(
     () => (data ? data.map((candle) => formatTimestamp(candle.openTime, timeframe)) : []),
@@ -561,7 +593,7 @@ function App() {
                 )}
               </div>
               <LineChart
-                title="RSI (14)"
+                title={`RSI (${rsiLengthDescription})`}
                 data={rsiValues}
                 labels={labels}
                 color="#818cf8"
@@ -569,7 +601,7 @@ function App() {
                 guideLines={rsiGuideLines}
               />
               <LineChart
-                title="Stochastic RSI (14)"
+                title={`Stochastic RSI (${rsiLengthDescription})`}
                 data={stochasticValues}
                 labels={labels}
                 color="#34d399"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -656,7 +656,7 @@ function App() {
                 labels={labels}
                 series={[
                   { name: '%K', data: stochasticSeries.kValues, color: '#34d399' },
-                  { name: '%D', data: stochasticSeries.dValues, color: '#38bdf8' },
+                  { name: '%D', data: stochasticSeries.dValues, color: '#f87171' },
                 ]}
                 yDomain={{ min: 0, max: 100 }}
                 guideLines={stochasticGuideLines}

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -281,7 +281,7 @@ export function LineChart({
               d={buildPath(points)}
               fill="none"
               stroke={resolvedSeries[index]?.color ?? DEFAULT_COLOR}
-              strokeWidth={1.25}
+              strokeWidth={0.625}
               strokeLinecap="round"
               strokeLinejoin="round"
             />

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -6,10 +6,17 @@ type GuideLine = {
   color: string
 }
 
+type LineSeries = {
+  name: string
+  data: Array<number | null>
+  color: string
+}
+
 type LineChartProps = {
   title: string
-  data: Array<number | null>
   labels: string[]
+  data?: Array<number | null>
+  series?: LineSeries[]
   color?: string
   yDomain?: {
     min?: number
@@ -21,6 +28,7 @@ type LineChartProps = {
 const DEFAULT_WIDTH = 640
 const DEFAULT_HEIGHT = 260
 const PADDING = 24
+const DEFAULT_COLOR = '#818cf8'
 
 function buildPath(points: Array<{ x: number; y: number } | null>): string {
   let path = ''
@@ -51,75 +59,112 @@ function formatAxisLabel(label: string): string {
 export function LineChart({
   title,
   data,
+  series,
   labels,
-  color = '#818cf8',
+  color = DEFAULT_COLOR,
   yDomain,
   guideLines = [],
 }: LineChartProps) {
   const gradientId = useId()
   const [isCollapsed, setIsCollapsed] = useState(false)
-  const chart = useMemo(() => {
-    const validValues = data.filter((value): value is number => value != null)
 
-    if (validValues.length === 0) {
+  const resolvedSeries = useMemo(() => {
+    if (series && series.length > 0) {
+      return series
+    }
+
+    if (data) {
+      return [
+        {
+          name: title,
+          data,
+          color: color ?? DEFAULT_COLOR,
+        },
+      ]
+    }
+
+    return []
+  }, [series, data, color, title])
+
+  const chart = useMemo(() => {
+    if (resolvedSeries.length === 0) {
       return null
     }
 
-    const minValue =
-      yDomain?.min ?? Math.min(...validValues, guideLines.length ? Math.min(...guideLines.map((line) => line.value)) : Infinity)
-    const maxValue =
-      yDomain?.max ?? Math.max(...validValues, guideLines.length ? Math.max(...guideLines.map((line) => line.value)) : -Infinity)
+    const allValues = resolvedSeries.flatMap((entry) =>
+      entry.data.filter((value): value is number => value != null),
+    )
 
-    const resolvedMin = Number.isFinite(minValue) ? minValue : Math.min(...validValues)
-    const resolvedMax = Number.isFinite(maxValue) ? maxValue : Math.max(...validValues)
+    if (allValues.length === 0) {
+      return null
+    }
 
+    const guideValues = guideLines.map((line) => line.value)
+    const dataMin = Math.min(...allValues)
+    const dataMax = Math.max(...allValues)
+    const guideMin = guideValues.length ? Math.min(...guideValues) : dataMin
+    const guideMax = guideValues.length ? Math.max(...guideValues) : dataMax
+
+    const minValue = yDomain?.min ?? Math.min(dataMin, guideMin)
+    const maxValue = yDomain?.max ?? Math.max(dataMax, guideMax)
+
+    const resolvedMin = Number.isFinite(minValue) ? minValue : dataMin
+    const resolvedMax = Number.isFinite(maxValue) ? maxValue : dataMax
     const range = resolvedMax - resolvedMin || 1
 
     const innerWidth = DEFAULT_WIDTH - PADDING * 2
     const innerHeight = DEFAULT_HEIGHT - PADDING * 2
 
-    const points = data.map((value, index) => {
-      if (value == null) {
-        return null
-      }
+    const labelsLength = labels.length
+    const fallbackLength = resolvedSeries[0]?.data.length ?? 0
+    const domainLength = Math.max((labelsLength || fallbackLength) - 1, 1)
 
-      const x = PADDING + (innerWidth * index) / Math.max(data.length - 1, 1)
-      const y = PADDING + innerHeight - ((value - resolvedMin) / range) * innerHeight
+    const pointsBySeries = resolvedSeries.map((entry) =>
+      entry.data.map((value, index) => {
+        if (value == null) {
+          return null
+        }
 
-      return { x, y }
-    })
+        const x = PADDING + (innerWidth * index) / domainLength
+        const y = PADDING + innerHeight - ((value - resolvedMin) / range) * innerHeight
+
+        return { x, y }
+      }),
+    )
 
     const ticks = [resolvedMin, resolvedMin + range / 2, resolvedMax].map((value) =>
       Number.isInteger(value) ? value : Number(value.toFixed(2)),
     )
 
     const labelIndexes = new Set<number>()
-    if (labels.length > 0) {
+    if (labelsLength > 0) {
       labelIndexes.add(0)
-      labelIndexes.add(labels.length - 1)
-      labelIndexes.add(Math.floor((labels.length - 1) / 2))
+      labelIndexes.add(labelsLength - 1)
+      labelIndexes.add(Math.floor((labelsLength - 1) / 2))
     }
 
     return {
       min: resolvedMin,
       max: resolvedMax,
-      range,
-      points,
+      pointsBySeries,
       ticks,
       labelIndexes: Array.from(labelIndexes).sort((a, b) => a - b),
     }
-  }, [data, labels.length, yDomain, guideLines])
+  }, [resolvedSeries, labels, yDomain, guideLines])
 
-  const latestValue = useMemo(() => {
-    for (let index = data.length - 1; index >= 0; index -= 1) {
-      const value = data[index]
-      if (value != null) {
-        return value
-      }
-    }
-
-    return null
-  }, [data])
+  const latestSeriesValues = useMemo(
+    () =>
+      resolvedSeries.map((entry) => {
+        for (let index = entry.data.length - 1; index >= 0; index -= 1) {
+          const value = entry.data[index]
+          if (value != null) {
+            return { name: entry.name, value }
+          }
+        }
+        return { name: entry.name, value: null }
+      }),
+    [resolvedSeries],
+  )
 
   if (!chart) {
     return (
@@ -129,7 +174,20 @@ export function LineChart({
     )
   }
 
-  const { points, ticks, labelIndexes, min, max } = chart
+  const hasSingleSeries = resolvedSeries.length === 1
+  const primaryLatestValue = hasSingleSeries ? latestSeriesValues[0]?.value ?? null : null
+  const gradientColor = resolvedSeries[0]?.color ?? color ?? DEFAULT_COLOR
+  const { pointsBySeries, ticks, labelIndexes, min, max } = chart
+
+  const getPointForIndex = (index: number) => {
+    for (const seriesPoints of pointsBySeries) {
+      const point = seriesPoints[index]
+      if (point) {
+        return point
+      }
+    }
+    return null
+  }
 
   return (
     <div className="flex h-full w-full flex-col gap-4 rounded-2xl border border-white/10 bg-slate-900/60 p-6">
@@ -137,12 +195,33 @@ export function LineChart({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
             <h2 className="text-base font-semibold text-white">{title}</h2>
-            {latestValue != null && (
+            {hasSingleSeries && primaryLatestValue != null && (
               <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-indigo-200">
-                Current {latestValue.toFixed(2)}
+                Current {primaryLatestValue.toFixed(2)}
               </span>
             )}
           </div>
+          {!hasSingleSeries && (
+            <div className="flex flex-wrap gap-2">
+              {latestSeriesValues.map(({ name, value }, index) => {
+                const seriesColor = resolvedSeries[index]?.color ?? DEFAULT_COLOR
+                return (
+                  <span
+                    key={`${name}-${index}`}
+                    className="flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold"
+                    style={{
+                      borderColor: seriesColor,
+                      color: seriesColor,
+                      backgroundColor: `${seriesColor}1a`,
+                    }}
+                  >
+                    <span>{name}</span>
+                    <span>{value != null ? value.toFixed(2) : '—'}</span>
+                  </span>
+                )
+              })}
+            </div>
+          )}
         </div>
         <button
           type="button"
@@ -156,81 +235,95 @@ export function LineChart({
       </div>
       {!isCollapsed && (
         <svg viewBox={`0 0 ${DEFAULT_WIDTH} ${DEFAULT_HEIGHT}`} className="w-full flex-1 text-white">
-          <defs>
-            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={color} stopOpacity="0.3" />
-              <stop offset="100%" stopColor={color} stopOpacity="0" />
-            </linearGradient>
-        </defs>
-        <rect
-          x={PADDING}
-          y={PADDING}
-          width={DEFAULT_WIDTH - PADDING * 2}
-          height={DEFAULT_HEIGHT - PADDING * 2}
-          fill={`url(#${gradientId})`}
-          opacity="0.1"
-        />
-        {guideLines.map((line) => {
-          const y =
-            PADDING + (DEFAULT_HEIGHT - PADDING * 2) -
-            ((line.value - min) / (max - min || 1)) * (DEFAULT_HEIGHT - PADDING * 2)
-          return (
-            <g key={line.label}>
-              <line
-                x1={PADDING}
-                x2={DEFAULT_WIDTH - PADDING}
-                y1={y}
-                y2={y}
-                stroke={line.color}
-                strokeDasharray="4 4"
-                strokeWidth={1}
-                opacity={0.6}
+          {hasSingleSeries && (
+            <>
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={gradientColor} stopOpacity="0.3" />
+                  <stop offset="100%" stopColor={gradientColor} stopOpacity="0" />
+                </linearGradient>
+              </defs>
+              <rect
+                x={PADDING}
+                y={PADDING}
+                width={DEFAULT_WIDTH - PADDING * 2}
+                height={DEFAULT_HEIGHT - PADDING * 2}
+                fill={`url(#${gradientId})`}
+                opacity="0.1"
               />
-              <text x={DEFAULT_WIDTH - PADDING} y={y - 4} textAnchor="end" className="fill-slate-400 text-[10px]">
-                {line.label}
-              </text>
-            </g>
-          )
-        })}
-        <path d={buildPath(points)} fill="none" stroke={color} strokeWidth={1.25} strokeLinecap="round" strokeLinejoin="round" />
-        {ticks.map((value) => {
-          const y =
-            PADDING + (DEFAULT_HEIGHT - PADDING * 2) -
-            ((value - min) / (max - min || 1)) * (DEFAULT_HEIGHT - PADDING * 2)
-          return (
-            <g key={`tick-${value}`}>
-              <line
-                x1={PADDING}
-                x2={DEFAULT_WIDTH - PADDING}
-                y1={y}
-                y2={y}
-                stroke="rgba(148, 163, 184, 0.2)"
-                strokeWidth={1}
-              />
-              <text x={PADDING - 8} y={y + 3} textAnchor="end" className="fill-slate-500 text-[10px]">
-                {value}
-              </text>
-            </g>
-          )
-        })}
-        {labelIndexes.map((index) => {
-          const point = points[index]
-          if (!point) {
-            return null
-          }
+            </>
+          )}
+          {guideLines.map((line) => {
+            const y =
+              PADDING + (DEFAULT_HEIGHT - PADDING * 2) -
+              ((line.value - min) / (max - min || 1)) * (DEFAULT_HEIGHT - PADDING * 2)
+            return (
+              <g key={line.label}>
+                <line
+                  x1={PADDING}
+                  x2={DEFAULT_WIDTH - PADDING}
+                  y1={y}
+                  y2={y}
+                  stroke={line.color}
+                  strokeDasharray="4 4"
+                  strokeWidth={1}
+                  opacity={0.6}
+                />
+                <text x={DEFAULT_WIDTH - PADDING} y={y - 4} textAnchor="end" className="fill-slate-400 text-[10px]">
+                  {line.label}
+                </text>
+              </g>
+            )
+          })}
+          {pointsBySeries.map((points, index) => (
+            <path
+              key={`series-${index}`}
+              d={buildPath(points)}
+              fill="none"
+              stroke={resolvedSeries[index]?.color ?? DEFAULT_COLOR}
+              strokeWidth={1.25}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))}
+          {ticks.map((value) => {
+            const y =
+              PADDING + (DEFAULT_HEIGHT - PADDING * 2) -
+              ((value - min) / (max - min || 1)) * (DEFAULT_HEIGHT - PADDING * 2)
+            return (
+              <g key={`tick-${value}`}>
+                <line
+                  x1={PADDING}
+                  x2={DEFAULT_WIDTH - PADDING}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(148, 163, 184, 0.2)"
+                  strokeWidth={1}
+                />
+                <text x={PADDING - 8} y={y + 3} textAnchor="end" className="fill-slate-500 text-[10px]">
+                  {value}
+                </text>
+              </g>
+            )
+          })}
+          {labelIndexes.map((index) => {
+            const point = getPointForIndex(index)
+            if (!point) {
+              return null
+            }
 
-          return (
-            <text
-              key={`label-${index}`}
-              x={point.x}
-              y={DEFAULT_HEIGHT - PADDING + 14}
-              textAnchor="middle"
-              className="fill-slate-500 text-[10px]"
-            >
-              {formatAxisLabel(labels[index])}
-            </text>
-          )
-        })}
+            return (
+              <text
+                key={`label-${index}`}
+                x={point.x}
+                y={DEFAULT_HEIGHT - PADDING + 14}
+                textAnchor="middle"
+                className="fill-slate-500 text-[10px]"
+              >
+                {formatAxisLabel(labels[index] ?? '')}
+              </text>
+            )
+          })}
         </svg>
       )}
     </div>


### PR DESCRIPTION
## Summary
- map each supported timeframe to the recommended RSI period range and expose descriptive labels
- drive RSI and Stochastic RSI calculations with the mapped period and show the active range in chart titles
- expand timeframe options to include 4h, 6h, and 7h labels that match the new recommendations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d53bd5879c8320aab40cb675f4d1d7