### PR TITLE
Update notification timeframe options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,9 +77,11 @@ const TIMEFRAMES: TimeframeOption[] = [
   { value: '360', label: '360m (6h)' },
 ]
 
-const NOTIFICATION_TIMEFRAME_OPTIONS = TIMEFRAMES.filter((option) =>
-  ['1', '5', '15'].includes(option.value),
-)
+const NOTIFICATION_TIMEFRAME_OPTIONS: TimeframeOption[] = [
+  { value: '1', label: '1m' },
+  { value: '5', label: '5m' },
+  { value: '15', label: '15m' },
+]
 
 const DEFAULT_NOTIFICATION_TIMEFRAME = NOTIFICATION_TIMEFRAME_OPTIONS[0]?.value ?? '1'
 


### PR DESCRIPTION
## Summary
- define explicit notification timeframe options to support 1m, 5m, and 15m intervals
- set the default notification interval to 1m

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d647f0dfa083208de0e4abd8c5e660