### PR TITLE
Ensure local notifications always display

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -193,11 +193,17 @@ export async function showAppNotification({
       return true
     }
 
-    const subscription = await registration.pushManager.getSubscription()
+    const showNotification = registration.showNotification(title, options)
 
-    if (!subscription) {
-      await registration.showNotification(title, options)
-      return true
+    void registration.pushManager
+      .getSubscription()
+      .catch((error) => console.warn('Failed to read push subscription', error))
+
+    try {
+      await showNotification
+    } catch (error) {
+      console.error('Service worker notification failed, falling back to Notification API', error)
+      new Notification(title, options)
     }
 
     return true


### PR DESCRIPTION
## Summary
- ensure `showAppNotification` always triggers a local notification regardless of push subscription availability
- log push subscription read failures and fall back to the Notification API if the service worker cannot display the alert

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d660b777e4832098996533feb375cf