### PR TITLE
Enhance momentum notification aggregation

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -169,7 +169,7 @@ export async function showAppNotification({
     return false
   }
 
-  const options: NotificationOptions = {
+  const options: NotificationOptions & { renotify?: boolean; timestamp?: number } = {
     body,
     tag,
     data,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -87,7 +87,7 @@ self.addEventListener('push', (event) => {
   })()
 
   const title = payload?.title ?? 'Momentum alert'
-  const options: NotificationOptions = {
+  const options: NotificationOptions & { renotify?: boolean; timestamp?: number } = {
     body: payload?.body ?? 'Open the app to view the latest trend insights.',
     tag: payload?.tag,
     icon: payload?.icon ?? '/icons/pwa-icon.svg',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,38 +3,40 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 
+const pwaOptions = {
+  registerType: 'prompt',
+  injectRegister: 'auto',
+  includeAssets: ['vite.svg', 'icons/pwa-icon.svg'],
+  srcDir: 'src',
+  filename: 'sw.ts',
+  strategies: 'injectManifest',
+  injectManifest: {
+    globPatterns: ['**/*.{js,css,html,svg,png,ico}'],
+  },
+  manifest: {
+    name: 'CryptoTrendNotify',
+    short_name: 'TrendNotify',
+    description: 'Installable crypto trend insights with offline-ready performance.',
+    theme_color: '#020617',
+    background_color: '#020617',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    icons: [
+      {
+        src: 'icons/pwa-icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any maskable',
+      },
+    ],
+  },
+}
+
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    VitePWA({
-      registerType: 'prompt',
-      injectRegister: 'auto',
-      includeAssets: ['vite.svg', 'icons/pwa-icon.svg'],
-      srcDir: 'src',
-      filename: 'sw.ts',
-      strategies: 'injectManifest',
-      injectManifest: {
-        globPatterns: ['**/*.{js,css,html,svg,png,ico}'],
-      },
-      manifest: {
-        name: 'CryptoTrendNotify',
-        short_name: 'TrendNotify',
-        description: 'Installable crypto trend insights with offline-ready performance.',
-        theme_color: '#020617',
-        background_color: '#020617',
-        start_url: '/',
-        scope: '/',
-        display: 'standalone',
-        icons: [
-          {
-            src: 'icons/pwa-icon.svg',
-            sizes: 'any',
-            type: 'image/svg+xml',
-            purpose: 'any maskable',
-          },
-        ],
-      },
-    }),
+    VitePWA(pwaOptions as Parameters<typeof VitePWA>[0]),
   ],
 })


### PR DESCRIPTION
## Summary
- compute momentum signals across 5m, 15m, 30m, and 60m candles to derive intensity levels and trigger consolidated app/push notifications with detailed messaging
- refresh the in-app momentum notification feed to display multi-timeframe readings with color-coded styling that matches the new intensity levels
- adjust notification option typing and reuse the Vite PWA configuration payload so TypeScript accepts the existing service worker build setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d66411a5dc8320a2f32276188ae13b