### PR TITLE
Add moving averages chart with crossover markers

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react'
-import type { MomentumIntensity, MomentumNotification } from '../App'
+import type { MomentumIntensity, MomentumNotification, MovingAverageMarker } from '../App'
 import { LineChart } from './LineChart'
 
 const MOMENTUM_EMOJI_BY_INTENSITY: Record<MomentumIntensity, string> = {
@@ -74,6 +74,12 @@ type DashboardViewProps = {
   priceChange: { difference: number; percent: number } | null
   isMarketSummaryCollapsed: boolean
   onToggleMarketSummary: () => void
+  movingAverageSeries: {
+    ema10: Array<number | null>
+    ema50: Array<number | null>
+    ma200: Array<number | null>
+    markers: MovingAverageMarker[]
+  }
   rsiLengthDescription: string
   rsiValues: Array<number | null>
   labels: string[]
@@ -136,6 +142,7 @@ export function DashboardView({
   priceChange,
   isMarketSummaryCollapsed,
   onToggleMarketSummary,
+  movingAverageSeries,
   rsiLengthDescription,
   rsiValues,
   labels,
@@ -562,14 +569,24 @@ export function DashboardView({
                         <span className="text-xs text-slate-500">Waiting for additional price data…</span>
                       )}
                     </div>
-                  </div>
-                )}
               </div>
-              <LineChart
-                title={`RSI (${rsiLengthDescription})`}
-                data={rsiValues}
-                labels={labels}
-                color="#818cf8"
+            )}
+          </div>
+          <LineChart
+            title="Moving averages (EMA 10 • EMA 50 • MA 200)"
+            labels={labels}
+            series={[
+              { name: 'EMA 10', data: movingAverageSeries.ema10, color: '#38bdf8' },
+              { name: 'EMA 50', data: movingAverageSeries.ema50, color: '#a855f7' },
+              { name: 'MA 200', data: movingAverageSeries.ma200, color: '#f97316' },
+            ]}
+            markers={movingAverageSeries.markers}
+          />
+          <LineChart
+            title={`RSI (${rsiLengthDescription})`}
+            data={rsiValues}
+            labels={labels}
+            color="#818cf8"
                 yDomain={{ min: 0, max: 100 }}
                 guideLines={rsiGuideLines}
               />

--- a/src/lib/indicators.ts
+++ b/src/lib/indicators.ts
@@ -38,6 +38,58 @@ export function calculateRSI(values: number[], period = DEFAULT_PERIOD): Array<n
   return result
 }
 
+export function calculateEMA(values: number[], period: number): Array<number | null> {
+  const normalizedPeriod = Math.max(1, Math.floor(period))
+  const result: Array<number | null> = new Array(values.length).fill(null)
+
+  if (values.length < normalizedPeriod) {
+    return result
+  }
+
+  let sum = 0
+  for (let i = 0; i < normalizedPeriod; i += 1) {
+    sum += values[i]
+  }
+
+  let previousEma = sum / normalizedPeriod
+  result[normalizedPeriod - 1] = previousEma
+
+  const multiplier = 2 / (normalizedPeriod + 1)
+
+  for (let i = normalizedPeriod; i < values.length; i += 1) {
+    const value = values[i]
+    previousEma = (value - previousEma) * multiplier + previousEma
+    result[i] = previousEma
+  }
+
+  return result
+}
+
+export function calculateSMA(values: number[], period: number): Array<number | null> {
+  const normalizedPeriod = Math.max(1, Math.floor(period))
+  const result: Array<number | null> = new Array(values.length).fill(null)
+
+  if (values.length < normalizedPeriod) {
+    return result
+  }
+
+  let windowSum = 0
+
+  for (let i = 0; i < values.length; i += 1) {
+    windowSum += values[i]
+
+    if (i >= normalizedPeriod) {
+      windowSum -= values[i - normalizedPeriod]
+    }
+
+    if (i >= normalizedPeriod - 1) {
+      result[i] = windowSum / normalizedPeriod
+    }
+  }
+
+  return result
+}
+
 type StochasticRSIOptions = {
   stochLength?: number
   kSmoothing?: number


### PR DESCRIPTION
## Summary
- calculate EMA(10), EMA(50), and MA(200) series from close prices and detect crossover events
- render a new moving averages panel above the RSI chart with crossover markers and tooltips
- extend the shared LineChart component to support marker overlays for visualizing crossovers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d691be8e98832093642d1d7a7ebfc5