### PR TITLE
Add dismissal controls to momentum notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,7 +338,15 @@ function formatTimestamp(timestamp: number, timeframe: string): string {
 }
 
 function formatTriggeredAt(timestamp: number): string {
-  return DATE_FORMATTERS.short.format(new Date(timestamp))
+  const date = new Date(timestamp)
+  const day = date.getDate().toString().padStart(2, '0')
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const year = date.getFullYear().toString()
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const seconds = date.getSeconds().toString().padStart(2, '0')
+
+  return `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`
 }
 
 function resolveBarLimit(selection: string, customValue: string): number | null {
@@ -1058,6 +1066,12 @@ function App() {
     setIsMarketSummaryCollapsed((previous) => !previous)
   }, [])
 
+  const dismissMomentumNotification = useCallback((notificationId: string) => {
+    setMomentumNotifications((previous) =>
+      previous.filter((notification) => notification.id !== notificationId),
+    )
+  }, [])
+
   const formatTriggeredAtLabel = useCallback(formatTriggeredAt, [])
 
   const handleInstall = async () => {
@@ -1135,6 +1149,7 @@ function App() {
       momentumThresholds={momentumThresholds}
       visibleMomentumNotifications={visibleMomentumNotifications}
       formatTriggeredAt={formatTriggeredAtLabel}
+      onDismissMomentumNotification={dismissMomentumNotification}
       lastUpdatedLabel={lastUpdatedLabel}
       refreshInterval={refreshInterval}
       formatIntervalLabel={formatIntervalLabel}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -66,6 +66,7 @@ type DashboardViewProps = {
   }
   visibleMomentumNotifications: MomentumNotification[]
   formatTriggeredAt: (timestamp: number) => string
+  onDismissMomentumNotification: (notificationId: string) => void
   lastUpdatedLabel: string
   refreshInterval: number | false
   formatIntervalLabel: (value: string) => string
@@ -134,6 +135,7 @@ export function DashboardView({
   momentumThresholds,
   visibleMomentumNotifications,
   formatTriggeredAt,
+  onDismissMomentumNotification,
   lastUpdatedLabel,
   refreshInterval,
   formatIntervalLabel,
@@ -499,11 +501,21 @@ export function DashboardView({
                       return (
                         <div
                           key={entry.id}
-                          className={`flex min-w-[220px] flex-1 flex-col gap-1 rounded-xl border px-3 py-2 text-xs ${cardClasses}`}
+                          className={`flex min-w-[220px] flex-1 flex-col gap-2 rounded-xl border px-3 py-2 text-xs ${cardClasses}`}
                         >
-                          <span className="text-[11px] font-semibold uppercase tracking-wide">
-                            {emoji} {entry.label}
-                          </span>
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="text-[11px] font-semibold uppercase tracking-wide">
+                              {emoji} {entry.label}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => onDismissMomentumNotification(entry.id)}
+                              className="flex h-6 w-6 items-center justify-center rounded-full border border-white/20 text-base text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+                              aria-label="Dismiss momentum notification"
+                            >
+                              ×
+                            </button>
+                          </div>
                           <span className="text-sm font-semibold text-white">{entry.symbol}</span>
                           <span className="text-[11px] text-white/80">Rsi {entry.rsiSummary}</span>
                           <span className="text-[11px] text-white/80">


### PR DESCRIPTION
## Summary
- format momentum notification timestamps with an explicit day/month/year and time stamp
- add a dismiss control for each momentum notification card and wire it to App state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da42c6e6bc83208bbbeeea34007104