### PR TITLE
Add header notification popup for alerts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -975,6 +975,11 @@ function App() {
     [movingAverageNotifications],
   )
 
+  const handleClearNotifications = useCallback(() => {
+    setMomentumNotifications([])
+    setMovingAverageNotifications([])
+  }, [])
+
   useEffect(() => {
     if (!notificationsEnabled) {
       return
@@ -1359,6 +1364,7 @@ function App() {
       formatTriggeredAt={formatTriggeredAtLabel}
       onDismissMomentumNotification={dismissMomentumNotification}
       onDismissMovingAverageNotification={dismissMovingAverageNotification}
+      onClearNotifications={handleClearNotifications}
       lastUpdatedLabel={lastUpdatedLabel}
       refreshInterval={refreshInterval}
       formatIntervalLabel={formatIntervalLabel}


### PR DESCRIPTION
## Summary
- replace the moving average and momentum panels with a notification bell in the header
- aggregate moving average and momentum alerts into a dropdown popup with dismiss and clear actions
- add a handler to clear stored notifications when requested

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6ad998b8832092ddc6042877d0ba