### PR TITLE
Add unit and end-to-end tests for CryptoTrendNotify

### DIFF
--- a/e2e/crypto-dashboard.spec.ts
+++ b/e2e/crypto-dashboard.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+
+type CandleTuple = [string, string, string, string, string, string, string]
+
+function buildCandleSeries(limit: number, intervalMinutes: number): CandleTuple[] {
+  const now = Date.now()
+  const intervalMs = intervalMinutes * 60_000
+  const startTime = Math.floor(now / intervalMs) * intervalMs
+
+  return Array.from({ length: limit }, (_, index) => {
+    const timestamp = startTime - index * intervalMs
+    const open = 100 + index * 0.5
+    const close = open + Math.sin(index / 3) * 2
+    const high = Math.max(open, close) + 0.5
+    const low = Math.min(open, close) - 0.5
+    const volume = 1000 + index * 10
+    const turnover = 500 + index * 5
+
+    return [
+      String(timestamp),
+      open.toFixed(2),
+      high.toFixed(2),
+      low.toFixed(2),
+      close.toFixed(2),
+      volume.toFixed(2),
+      turnover.toFixed(2),
+    ]
+  })
+}
+
+test.describe('Crypto momentum dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('https://api.bybit.com/v5/market/kline**', async (route) => {
+      const url = new URL(route.request().url())
+      const limit = Number.parseInt(url.searchParams.get('limit') ?? '200', 10)
+      const interval = Number.parseInt(url.searchParams.get('interval') ?? '1', 10)
+      const candles = buildCandleSeries(limit, interval)
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          retCode: 0,
+          retMsg: 'OK',
+          result: {
+            list: candles,
+          },
+        }),
+      })
+    })
+  })
+
+  test('allows configuring the market view', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Crypto momentum dashboard' })).toBeVisible()
+
+    const symbolSelect = page.getByLabel('Crypto')
+    await expect(symbolSelect).toHaveValue('DOGEUSDT')
+    await symbolSelect.selectOption('BTCUSDT')
+    await expect(symbolSelect).toHaveValue('BTCUSDT')
+
+    const timeframeSelect = page.getByLabel('Timeframe')
+    await timeframeSelect.selectOption('120')
+    await expect(timeframeSelect).toHaveValue('120')
+
+    const marketSummaryHeading = page.getByRole('heading', { level: 2, name: 'Market snapshot' })
+    const marketSummaryToggle = marketSummaryHeading.locator('..').locator('..').getByRole('button')
+    await expect(marketSummaryHeading).toBeVisible()
+    await marketSummaryToggle.click()
+    await expect(marketSummaryToggle).toHaveText(/Expand/)
+
+    await expect(page.getByRole('button', { name: /Refresh now/i })).toBeEnabled()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "push:server": "node server/index.js"
+    "push:server": "node server/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.2",
@@ -27,10 +30,16 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.50.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "@types/testing-library__jest-dom": "^6.4.5",
+    "@types/node": "^22.13.5",
     "@vitejs/plugin-react": "^5.0.3",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
@@ -41,6 +50,7 @@
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",
     "vite-plugin-pwa": "^1.0.3",
+    "vitest": "^3.0.5",
     "workbox-window": "^7.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tailwindcss/vite": "^4.1.13",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "@vitest/coverage-v8": "^3.0.5",
     "@types/testing-library__jest-dom": "^6.4.5",
     "@types/node": "^22.13.5",
     "@vitejs/plugin-react": "^5.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test'
+
+const PORT = process.env.PORT ?? '4173'
+const HOST = process.env.HOST ?? '127.0.0.1'
+const baseURL = `http://${HOST}:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npm run dev -- --host ${HOST} --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/server/__tests__/push-subscription-store.test.ts
+++ b/server/__tests__/push-subscription-store.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+
+import { PushSubscriptionStore } from '../push-subscription-store.js'
+
+type TestContext = {
+  directory: string
+  filePath: string
+}
+
+describe('PushSubscriptionStore', () => {
+  const context: TestContext = {
+    directory: '',
+    filePath: '',
+  }
+
+  beforeEach(async () => {
+    context.directory = await mkdtemp(path.join(tmpdir(), 'push-store-'))
+    context.filePath = path.join(context.directory, 'subscriptions.json')
+  })
+
+  afterEach(async () => {
+    if (context.directory) {
+      await rm(context.directory, { recursive: true, force: true })
+    }
+  })
+
+  it('loads existing subscriptions on init', async () => {
+    const existing = [
+      { endpoint: 'https://example.com/1', keys: { p256dh: 'a', auth: 'b' } },
+      { endpoint: 'https://example.com/2', keys: { p256dh: 'c', auth: 'd' } },
+    ]
+
+    await writeFile(context.filePath, JSON.stringify(existing, null, 2))
+
+    const store = new PushSubscriptionStore(context.filePath)
+    await store.init()
+
+    expect(store.list()).toEqual(existing)
+  })
+
+  it('upserts and de-duplicates subscriptions', async () => {
+    const store = new PushSubscriptionStore(context.filePath)
+    await store.init()
+
+    const first = { endpoint: 'https://example.com/1', keys: { p256dh: 'a', auth: 'b' } }
+    const updated = { endpoint: 'https://example.com/1', keys: { p256dh: 'x', auth: 'y' } }
+
+    await store.upsert(first as any)
+    await store.upsert(updated as any)
+
+    expect(store.list()).toEqual([updated])
+  })
+
+  it('removes subscriptions by endpoint', async () => {
+    const store = new PushSubscriptionStore(context.filePath)
+    await store.init()
+
+    await store.upsert({ endpoint: 'https://example.com/1', keys: { p256dh: 'a', auth: 'b' } } as any)
+    await store.upsert({ endpoint: 'https://example.com/2', keys: { p256dh: 'c', auth: 'd' } } as any)
+
+    const removed = await store.remove('https://example.com/1')
+
+    expect(removed).toBe(true)
+    expect(store.list()).toEqual([
+      { endpoint: 'https://example.com/2', keys: { p256dh: 'c', auth: 'd' } },
+    ])
+    expect(await store.remove('https://example.com/missing')).toBe(false)
+  })
+})

--- a/src/components/__tests__/LineChart.test.tsx
+++ b/src/components/__tests__/LineChart.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { LineChart } from '../LineChart'
+
+describe('LineChart', () => {
+  it('displays the latest value badge for a single series', () => {
+    render(
+      <LineChart
+        title="RSI"
+        labels={['A', 'B', 'C']}
+        data={[45.1, 47.25, 50.32]}
+      />,
+    )
+
+    expect(screen.getByText(/Current 50\.32/)).toBeInTheDocument()
+  })
+
+  it('renders a friendly fallback when data is missing', () => {
+    render(
+      <LineChart
+        title="RSI"
+        labels={['A', 'B', 'C']}
+        data={[null, null, null]}
+      />,
+    )
+
+    expect(screen.getByText('No data available for this selection.')).toBeVisible()
+  })
+
+  it('allows collapsing and expanding the chart area', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <LineChart
+        title="Momentum"
+        labels={['A', 'B', 'C', 'D']}
+        data={[30, 40, 50, 60]}
+      />,
+    )
+
+    const toggle = screen.getByRole('button', { name: /Collapse/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(document.querySelectorAll('svg')).toHaveLength(1)
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveTextContent('Expand')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(document.querySelectorAll('svg')).toHaveLength(0)
+  })
+})

--- a/src/components/__tests__/LineChart.test.tsx
+++ b/src/components/__tests__/LineChart.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { LineChart } from '../LineChart'
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('LineChart', () => {
   it('displays the latest value badge for a single series', () => {
@@ -32,7 +36,7 @@ describe('LineChart', () => {
   it('allows collapsing and expanding the chart area', async () => {
     const user = userEvent.setup()
 
-    render(
+    const { container } = render(
       <LineChart
         title="Momentum"
         labels={['A', 'B', 'C', 'D']}
@@ -42,12 +46,45 @@ describe('LineChart', () => {
 
     const toggle = screen.getByRole('button', { name: /Collapse/ })
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
-    expect(document.querySelectorAll('svg')).toHaveLength(1)
+    expect(container.querySelectorAll('svg')).toHaveLength(1)
 
     await user.click(toggle)
 
     expect(toggle).toHaveTextContent('Expand')
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    expect(document.querySelectorAll('svg')).toHaveLength(0)
+    expect(container.querySelectorAll('svg')).toHaveLength(0)
+  })
+
+  it('summarizes the latest values for multiple series', () => {
+    render(
+      <LineChart
+        title="Momentum"
+        labels={['A', 'B', 'C']}
+        series={[
+          { name: 'Fast', color: '#ef4444', data: [1, 2, 3] },
+          { name: 'Slow', color: '#22c55e', data: [null, 4, 5] },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Fast')).toBeVisible()
+    expect(screen.getByText('Slow')).toBeVisible()
+    expect(screen.getByText('3.00')).toBeInTheDocument()
+    expect(screen.getByText('5.00')).toBeInTheDocument()
+  })
+
+  it('shows a loading status overlay when re-fetching data', () => {
+    const { container } = render(
+      <LineChart
+        title="RSI"
+        labels={['A', 'B']}
+        data={[30, 40]}
+        isLoading
+      />,
+    )
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveTextContent('Reloading chart data…')
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull()
   })
 })

--- a/src/lib/__tests__/indicators.test.ts
+++ b/src/lib/__tests__/indicators.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateEMA, calculateRSI, calculateSMA, calculateStochasticRSI } from '../indicators'
+
+describe('calculateRSI', () => {
+  it('returns null entries when data length is less than period', () => {
+    const values = [100, 101, 102]
+    const result = calculateRSI(values, 5)
+
+    expect(result).toHaveLength(values.length)
+    expect(result.every((entry) => entry === null)).toBe(true)
+  })
+
+  it('calculates incremental RSI values for a sliding window', () => {
+    const values = [44.34, 44.09, 44.15, 43.61, 44.33, 44.83, 45.10, 45.42]
+    const result = calculateRSI(values, 5)
+
+    expect(result.slice(0, 5)).toEqual([null, null, null, null, expect.any(Number)])
+    expect(result[5]).toBeCloseTo(59.029, 3)
+    expect(result[7]).toBeCloseTo(73.212, 3)
+  })
+})
+
+describe('calculateEMA', () => {
+  it('produces nulls until enough values are received', () => {
+    const values = [10, 20, 30]
+    const result = calculateEMA(values, 4)
+
+    expect(result).toEqual([null, null, null])
+  })
+
+  it('smooths the input values using the exponential formula', () => {
+    const values = [10, 11, 13, 12, 14]
+    const result = calculateEMA(values, 3)
+
+    expect(result.slice(0, 3)).toEqual([null, null, expect.any(Number)])
+    expect(result[2]).toBeCloseTo(11.333, 3)
+    expect(result[4]).toBeCloseTo(13.312, 3)
+  })
+})
+
+describe('calculateSMA', () => {
+  it('yields a moving average once the window is filled', () => {
+    const values = [1, 2, 3, 4, 5]
+    const result = calculateSMA(values, 3)
+
+    expect(result).toEqual([null, null, 2, 3, 4])
+  })
+})
+
+describe('calculateStochasticRSI', () => {
+  it('derives %K and %D series from RSI values', () => {
+    const rsiValues = [null, 40, 45, 55, 60, 50, 65, 70]
+    const { kValues, dValues } = calculateStochasticRSI(rsiValues, {
+      stochLength: 3,
+      kSmoothing: 2,
+      dSmoothing: 2,
+    })
+
+    expect(kValues.slice(0, 2)).toEqual([null, null])
+    expect(kValues[4]).toBeCloseTo(100, 3)
+    expect(kValues[6]).toBeGreaterThan(0)
+    expect(dValues[6]).toBeGreaterThan(0)
+    expect(dValues[6]).toBeLessThanOrEqual(100)
+  })
+
+  it('returns zeros when the RSI range collapses', () => {
+    const rsiValues = [50, 50, 50, 50]
+    const { kValues, dValues } = calculateStochasticRSI(rsiValues, {
+      stochLength: 2,
+      kSmoothing: 2,
+      dSmoothing: 2,
+    })
+
+    expect(kValues.filter((value) => value !== null)).toEqual([0, 0, 0])
+    expect(dValues.filter((value) => value !== null)).toEqual([0, 0])
+  })
+})

--- a/src/lib/__tests__/indicators.test.ts
+++ b/src/lib/__tests__/indicators.test.ts
@@ -37,6 +37,14 @@ describe('calculateEMA', () => {
     expect(result[2]).toBeCloseTo(11.333, 3)
     expect(result[4]).toBeCloseTo(13.312, 3)
   })
+
+  it('normalizes the period to avoid division by zero', () => {
+    const values = [5, 6, 7]
+    const result = calculateEMA(values, 0)
+
+    expect(result[0]).toBe(5)
+    expect(result[1]).toBeCloseTo(6, 5)
+  })
 })
 
 describe('calculateSMA', () => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "types": [],
+    "types": ["node", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vitest" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { defineConfig } from 'vitest/config'
 
 const pwaOptions = {
   registerType: 'prompt',
@@ -48,6 +48,7 @@ export default defineConfig({
       ['server/**/*.test.{ts,tsx}', 'node'],
     ],
     coverage: {
+      provider: 'v8',
       reporter: ['text', 'html'],
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,4 +39,16 @@ export default defineConfig({
     tailwindcss(),
     VitePWA(pwaOptions as Parameters<typeof VitePWA>[0]),
   ],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true,
+    environmentMatchGlobs: [
+      ['server/**/*.test.{ts,tsx}', 'node'],
+    ],
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add Vitest configuration, setup file, and testing dependencies to support unit testing
- cover indicator calculations, the LineChart component, and the push subscription store with targeted unit tests
- configure Playwright and add an end-to-end dashboard smoke test that stubs Bybit API traffic

## Testing
- not run (npm install for new dev dependencies is blocked in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68da7f176ba08320a44b3b9140befd8d