### PR TITLE
Allow custom crypto symbol entry

### DIFF
--- a/server/market-watcher.js
+++ b/server/market-watcher.js
@@ -10,10 +10,9 @@ function normalizeSymbol(value) {
   return trimmed.length > 0 ? trimmed : null
 }
 
-const DEFAULT_SYMBOLS = (process.env.PUSH_WATCH_SYMBOLS
+const ENV_SYMBOLS = (process.env.PUSH_WATCH_SYMBOLS
   ? process.env.PUSH_WATCH_SYMBOLS.split(',')
-  : ['DOGEUSDT', 'BTCUSDT', 'ETHUSDT', 'XRPUSDT', 'SOLUSDT']
-)
+  : [])
   .map((symbol) => normalizeSymbol(symbol))
   .filter(Boolean)
 
@@ -227,7 +226,7 @@ export function startMarketWatch({ store }) {
       ordered.push(normalized)
     }
 
-    for (const symbol of DEFAULT_SYMBOLS) {
+    for (const symbol of ENV_SYMBOLS) {
       addSymbol(symbol)
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,7 @@ export type MovingAverageCrossNotification = {
   triggeredAt: number
 }
 
-const CRYPTO_OPTIONS = ['DOGEUSDT', 'BTCUSDT', 'ETHUSDT', 'XRPUSDT', 'SOLUSDT']
+const DEFAULT_SYMBOL = 'BTCUSDT'
 
 const TIMEFRAMES: TimeframeOption[] = [
   { value: '5', label: '5m' },
@@ -435,7 +435,11 @@ function App() {
 
   const [symbol, setSymbol] = useState(() => {
     const stored = readLocalStorage(STORAGE_KEYS.symbol)
-    return stored && CRYPTO_OPTIONS.includes(stored) ? stored : CRYPTO_OPTIONS[0]
+    if (typeof stored === 'string' && stored.trim().length > 0) {
+      return stored.toUpperCase()
+    }
+
+    return DEFAULT_SYMBOL
   })
   const [timeframe, setTimeframe] = useState(() => {
     const stored = readLocalStorage(STORAGE_KEYS.timeframe)
@@ -1353,7 +1357,6 @@ function App() {
       onDismissOfflineReadyBanner={dismissOfflineReadyBanner}
       symbol={symbol}
       onSymbolChange={setSymbol}
-      cryptoOptions={CRYPTO_OPTIONS}
       timeframe={timeframe}
       timeframeOptions={TIMEFRAMES}
       onTimeframeChange={setTimeframe}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -467,7 +467,9 @@ export function DashboardView({
                   id="symbol"
                   type="text"
                   value={symbol}
-                  onChange={(event) => onSymbolChange(event.target.value.toUpperCase())}
+                  onChange={(event) =>
+                    onSymbolChange(event.target.value.replace(/[^a-z0-9]/gi, '').toUpperCase())
+                  }
                   placeholder="e.g. BTCUSDT"
                   className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium uppercase tracking-wide text-white shadow focus:border-indigo-400 focus:outline-none"
                 />

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -38,7 +38,6 @@ type DashboardViewProps = {
   onDismissOfflineReadyBanner: () => void
   symbol: string
   onSymbolChange: Dispatch<SetStateAction<string>>
-  cryptoOptions: string[]
   timeframe: string
   timeframeOptions: Array<{ value: string; label: string }>
   onTimeframeChange: Dispatch<SetStateAction<string>>
@@ -115,7 +114,6 @@ export function DashboardView({
   onDismissOfflineReadyBanner,
   symbol,
   onSymbolChange,
-  cryptoOptions,
   timeframe,
   timeframeOptions,
   onTimeframeChange,
@@ -465,18 +463,14 @@ export function DashboardView({
                 <label htmlFor="symbol" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
                   Crypto
                 </label>
-                <select
+                <input
                   id="symbol"
+                  type="text"
                   value={symbol}
-                  onChange={(event) => onSymbolChange(event.target.value)}
-                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                >
-                  {cryptoOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(event) => onSymbolChange(event.target.value.toUpperCase())}
+                  placeholder="e.g. BTCUSDT"
+                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium uppercase tracking-wide text-white shadow focus:border-indigo-400 focus:outline-none"
+                />
               </div>
               <div className="flex flex-col gap-2">
                 <label htmlFor="timeframe" className="text-xs font-semibold uppercase tracking-wider text-slate-400">


### PR DESCRIPTION
## Summary
- replace the crypto pair dropdown with a text input that defaults to BTCUSDT
- persist the chosen symbol in local storage alongside other filter selections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdedd7c748320802825903014c793