### PR TITLE
Add risk management sidebar panel with persistent equity input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -413,6 +413,8 @@ const STORAGE_KEYS = {
   stochasticLowerBound: 'ctn:stochasticLowerBound',
   stochasticUpperBound: 'ctn:stochasticUpperBound',
   currentEquity: 'ctn:currentEquity',
+  riskBudgetPercent: 'ctn:riskBudgetPercent',
+  atrMultiplier: 'ctn:atrMultiplier',
 } as const
 
 const isBrowser = typeof window !== 'undefined'
@@ -831,6 +833,12 @@ function App() {
   const [currentEquityInput, setCurrentEquityInput] = useState(
     () => readLocalStorage(STORAGE_KEYS.currentEquity) ?? '',
   )
+  const [riskBudgetPercentInput, setRiskBudgetPercentInput] = useState(
+    () => readLocalStorage(STORAGE_KEYS.riskBudgetPercent) ?? '0.75',
+  )
+  const [atrMultiplierInput, setAtrMultiplierInput] = useState(
+    () => readLocalStorage(STORAGE_KEYS.atrMultiplier) ?? '1',
+  )
   const notificationTimeframes = MOMENTUM_SIGNAL_TIMEFRAMES
   const lastMomentumTriggerRef = useRef<string | null>(null)
   const lastMovingAverageTriggersRef = useRef<Record<string, string>>({})
@@ -902,6 +910,14 @@ function App() {
   useEffect(() => {
     writeLocalStorage(STORAGE_KEYS.currentEquity, currentEquityInput)
   }, [currentEquityInput])
+
+  useEffect(() => {
+    writeLocalStorage(STORAGE_KEYS.riskBudgetPercent, riskBudgetPercentInput)
+  }, [riskBudgetPercentInput])
+
+  useEffect(() => {
+    writeLocalStorage(STORAGE_KEYS.atrMultiplier, atrMultiplierInput)
+  }, [atrMultiplierInput])
 
   const fetchPushServerStatus = useCallback(async () => checkPushServerConnection(), [])
 
@@ -2293,6 +2309,10 @@ function App() {
       onStochasticUpperBoundInputChange={setStochasticUpperBoundInput}
       currentEquity={currentEquityInput}
       onCurrentEquityChange={setCurrentEquityInput}
+      riskBudgetPercent={riskBudgetPercentInput}
+      onRiskBudgetPercentChange={setRiskBudgetPercentInput}
+      atrMultiplier={atrMultiplierInput}
+      onAtrMultiplierChange={setAtrMultiplierInput}
       momentumThresholds={momentumThresholds}
       visibleMomentumNotifications={visibleMomentumNotifications}
       visibleMovingAverageNotifications={visibleMovingAverageNotifications}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -412,6 +412,7 @@ const STORAGE_KEYS = {
   rsiUpperBound: 'ctn:rsiUpperBound',
   stochasticLowerBound: 'ctn:stochasticLowerBound',
   stochasticUpperBound: 'ctn:stochasticUpperBound',
+  currentEquity: 'ctn:currentEquity',
 } as const
 
 const isBrowser = typeof window !== 'undefined'
@@ -827,6 +828,9 @@ function App() {
       readLocalStorage(STORAGE_KEYS.stochasticUpperBound) ??
       DEFAULT_MOMENTUM_BOUNDS.stochasticUpper.toString(),
   )
+  const [currentEquityInput, setCurrentEquityInput] = useState(
+    () => readLocalStorage(STORAGE_KEYS.currentEquity) ?? '',
+  )
   const notificationTimeframes = MOMENTUM_SIGNAL_TIMEFRAMES
   const lastMomentumTriggerRef = useRef<string | null>(null)
   const lastMovingAverageTriggersRef = useRef<Record<string, string>>({})
@@ -894,6 +898,10 @@ function App() {
   useEffect(() => {
     writeLocalStorage(STORAGE_KEYS.stochasticUpperBound, stochasticUpperBoundInput)
   }, [stochasticUpperBoundInput])
+
+  useEffect(() => {
+    writeLocalStorage(STORAGE_KEYS.currentEquity, currentEquityInput)
+  }, [currentEquityInput])
 
   const fetchPushServerStatus = useCallback(async () => checkPushServerConnection(), [])
 
@@ -2283,6 +2291,8 @@ function App() {
       onStochasticLowerBoundInputChange={setStochasticLowerBoundInput}
       stochasticUpperBoundInput={stochasticUpperBoundInput}
       onStochasticUpperBoundInputChange={setStochasticUpperBoundInput}
+      currentEquity={currentEquityInput}
+      onCurrentEquityChange={setCurrentEquityInput}
       momentumThresholds={momentumThresholds}
       visibleMomentumNotifications={visibleMomentumNotifications}
       visibleMovingAverageNotifications={visibleMovingAverageNotifications}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -750,6 +750,7 @@ export function DashboardView({
             onCurrentEquityChange={onCurrentEquityChange}
             isCollapsed={isRiskPanelCollapsed}
             onToggleCollapse={() => setIsRiskPanelCollapsed((previous) => !previous)}
+            results={heatmapResults}
           />
         </aside>
       </main>

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -423,12 +423,6 @@ export function DashboardView({
           className={`${isSidebarOpen ? 'flex lg:flex' : 'hidden lg:hidden'} w-full flex-col gap-6 lg:w-80 lg:flex-shrink-0 lg:sticky lg:top-28`}
           aria-label="Dashboard filters and market snapshot"
         >
-          <RiskManagementPanel
-            currentEquity={currentEquity}
-            onCurrentEquityChange={onCurrentEquityChange}
-            isCollapsed={isRiskPanelCollapsed}
-            onToggleCollapse={() => setIsRiskPanelCollapsed((previous) => !previous)}
-          />
           <section className="flex flex-col gap-6 rounded-3xl border border-white/5 bg-slate-900/60 p-6">
             <div className="grid gap-6 sm:grid-cols-2">
               <div className="flex flex-col gap-3">
@@ -750,6 +744,14 @@ export function DashboardView({
             </>
           )}
         </section>
+        <aside className="flex w-full flex-col gap-6 lg:w-80 lg:flex-shrink-0 lg:sticky lg:top-28">
+          <RiskManagementPanel
+            currentEquity={currentEquity}
+            onCurrentEquityChange={onCurrentEquityChange}
+            isCollapsed={isRiskPanelCollapsed}
+            onToggleCollapse={() => setIsRiskPanelCollapsed((previous) => !previous)}
+          />
+        </aside>
       </main>
 
       <footer className="border-t border-white/5 bg-slate-950/80">

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -72,6 +72,10 @@ type DashboardViewProps = {
   onStochasticUpperBoundInputChange: Dispatch<SetStateAction<string>>
   currentEquity: string
   onCurrentEquityChange: Dispatch<SetStateAction<string>>
+  riskBudgetPercent: string
+  onRiskBudgetPercentChange: Dispatch<SetStateAction<string>>
+  atrMultiplier: string
+  onAtrMultiplierChange: Dispatch<SetStateAction<string>>
   momentumThresholds: {
     longRsi: number
     shortRsi: number
@@ -151,6 +155,10 @@ export function DashboardView({
   onStochasticUpperBoundInputChange,
   currentEquity,
   onCurrentEquityChange,
+  riskBudgetPercent,
+  onRiskBudgetPercentChange,
+  atrMultiplier,
+  onAtrMultiplierChange,
   momentumThresholds,
   visibleMovingAverageNotifications,
   visibleMomentumNotifications,
@@ -836,6 +844,10 @@ export function DashboardView({
           <RiskManagementPanel
             currentEquity={currentEquity}
             onCurrentEquityChange={onCurrentEquityChange}
+            riskBudgetPercent={riskBudgetPercent}
+            onRiskBudgetPercentChange={onRiskBudgetPercentChange}
+            atrMultiplier={atrMultiplier}
+            onAtrMultiplierChange={onAtrMultiplierChange}
             isCollapsed={isRiskPanelCollapsed}
             onToggleCollapse={() => setIsRiskPanelCollapsed((previous) => !previous)}
             results={heatmapResults}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -6,6 +6,7 @@ import type {
   MovingAverageMarker,
 } from '../App'
 import { LineChart } from './LineChart'
+import { RiskManagementPanel } from './RiskManagementPanel'
 import { RsiStochRsiHeatmap } from './RsiStochRsiHeatmap'
 import type { HeatmapResult } from '../types/heatmap'
 
@@ -69,6 +70,8 @@ type DashboardViewProps = {
   onStochasticLowerBoundInputChange: Dispatch<SetStateAction<string>>
   stochasticUpperBoundInput: string
   onStochasticUpperBoundInputChange: Dispatch<SetStateAction<string>>
+  currentEquity: string
+  onCurrentEquityChange: Dispatch<SetStateAction<string>>
   momentumThresholds: {
     longRsi: number
     shortRsi: number
@@ -146,6 +149,8 @@ export function DashboardView({
   onStochasticLowerBoundInputChange,
   stochasticUpperBoundInput,
   onStochasticUpperBoundInputChange,
+  currentEquity,
+  onCurrentEquityChange,
   momentumThresholds,
   visibleMovingAverageNotifications,
   visibleMomentumNotifications,
@@ -176,6 +181,7 @@ export function DashboardView({
 
   const [isNotificationPopupOpen, setIsNotificationPopupOpen] = useState(false)
   const [isSidebarOpen, setIsSidebarOpen] = useState(true)
+  const [isRiskPanelCollapsed, setIsRiskPanelCollapsed] = useState(false)
 
   const allNotifications = useMemo(
     () =>
@@ -417,6 +423,12 @@ export function DashboardView({
           className={`${isSidebarOpen ? 'flex lg:flex' : 'hidden lg:hidden'} w-full flex-col gap-6 lg:w-80 lg:flex-shrink-0 lg:sticky lg:top-28`}
           aria-label="Dashboard filters and market snapshot"
         >
+          <RiskManagementPanel
+            currentEquity={currentEquity}
+            onCurrentEquityChange={onCurrentEquityChange}
+            isCollapsed={isRiskPanelCollapsed}
+            onToggleCollapse={() => setIsRiskPanelCollapsed((previous) => !previous)}
+          />
           <section className="flex flex-col gap-6 rounded-3xl border border-white/5 bg-slate-900/60 p-6">
             <div className="grid gap-6 sm:grid-cols-2">
               <div className="flex flex-col gap-3">

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -180,7 +180,7 @@ export function DashboardView({
     Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2)
 
   const [isNotificationPopupOpen, setIsNotificationPopupOpen] = useState(false)
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
   const [isRiskPanelCollapsed, setIsRiskPanelCollapsed] = useState(false)
 
   const allNotifications = useMemo(
@@ -211,10 +211,6 @@ export function DashboardView({
     setIsNotificationPopupOpen((previous) => !previous)
   }
 
-  const handleToggleSidebar = () => {
-    setIsSidebarOpen((previous) => !previous)
-  }
-
   const handleClearNotifications = () => {
     onClearNotifications()
     setIsNotificationPopupOpen(false)
@@ -232,15 +228,6 @@ export function DashboardView({
             <p className="text-sm text-slate-400">Live Bybit OHLCV data with RSI signals ready for the web and PWA.</p>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={handleToggleSidebar}
-              className="rounded-full border border-indigo-400/60 px-4 py-2 text-sm font-semibold text-indigo-100 transition hover:border-indigo-300 hover:text-white"
-              aria-expanded={isSidebarOpen}
-              aria-controls="dashboard-sidebar"
-            >
-              {isSidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
-            </button>
             <button
               type="button"
               onClick={() => void onManualRefresh()}
@@ -420,223 +407,320 @@ export function DashboardView({
       <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-6 py-8 lg:flex-row lg:items-start lg:gap-10">
         <aside
           id="dashboard-sidebar"
-          className={`${isSidebarOpen ? 'flex lg:flex' : 'hidden lg:hidden'} w-full flex-col gap-6 lg:w-80 lg:flex-shrink-0 lg:sticky lg:top-28`}
+          className={`relative flex w-full flex-col gap-6 transition-[width] duration-300 lg:sticky lg:top-28 lg:flex-shrink-0 ${
+            isSidebarCollapsed ? 'lg:w-16' : 'lg:w-80'
+          }`}
           aria-label="Dashboard filters and market snapshot"
         >
-          <section className="flex flex-col gap-6 rounded-3xl border border-white/5 bg-slate-900/60 p-6">
-            <div className="grid gap-6 sm:grid-cols-2">
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Push server</span>
-                  {pushServerConnected === null ? (
-                    <span className="text-[11px] text-slate-500">Checking…</span>
-                  ) : pushServerConnected ? (
-                    <span className="rounded-full bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold text-emerald-200">Connected</span>
-                  ) : (
-                    <span className="rounded-full bg-rose-500/15 px-3 py-1 text-[11px] font-semibold text-rose-200">Offline</span>
-                  )}
+          <section
+            className={`flex flex-col gap-6 rounded-3xl border border-white/5 bg-slate-900/60 transition-[padding,opacity,transform] duration-300 ${
+              isSidebarCollapsed ? 'items-center gap-4 px-3 py-4' : 'p-6'
+            }`}
+          >
+            <div
+              className={`flex w-full items-center ${
+                isSidebarCollapsed ? 'justify-center' : 'justify-between'
+              } gap-3`}
+            >
+              {!isSidebarCollapsed && (
+                <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-300">
+                  Filters
+                </h2>
+              )}
+              <button
+                type="button"
+                onClick={() => setIsSidebarCollapsed((previous) => !previous)}
+                className={`flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/60 text-xs font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-white ${
+                  isSidebarCollapsed ? 'px-2 py-2' : 'px-3 py-1'
+                }`}
+                aria-expanded={!isSidebarCollapsed}
+              >
+                <span className="sr-only">
+                  {isSidebarCollapsed ? 'Show dashboard filters' : 'Hide dashboard filters'}
+                </span>
+                <span aria-hidden="true" className="text-lg leading-none">
+                  {isSidebarCollapsed ? '⟩' : '⟨'}
+                </span>
+                {!isSidebarCollapsed && <span aria-hidden="true">Hide</span>}
+                {isSidebarCollapsed && <span aria-hidden="true" className="text-[11px]">Show</span>}
+              </button>
+            </div>
+            {!isSidebarCollapsed && (
+              <>
+                <div className="grid gap-6 sm:grid-cols-2">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Push server</span>
+                      {pushServerConnected === null ? (
+                        <span className="text-[11px] text-slate-500">Checking…</span>
+                      ) : pushServerConnected ? (
+                        <span className="rounded-full bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold text-emerald-200">Connected</span>
+                      ) : (
+                        <span className="rounded-full bg-rose-500/15 px-3 py-1 text-[11px] font-semibold text-rose-200">Offline</span>
+                      )}
+                    </div>
+                    {pushServerConnected === false && (
+                      <span className="text-[11px] text-rose-300">
+                        Unable to reach the push server. Start the backend service to deliver notifications.
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">Notifications</span>
+                      {supportsNotifications ? (
+                        notificationPermission === 'granted' ? (
+                          <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-[11px] font-semibold text-emerald-300">Enabled</span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => void onEnableNotifications()}
+                            className="rounded-full border border-indigo-400/60 px-3 py-1 text-[11px] font-semibold text-indigo-100 transition hover:border-indigo-300 hover:text-white"
+                          >
+                            Enable alerts
+                          </button>
+                        )
+                      ) : (
+                        <span className="text-[11px] text-slate-500">Not supported in this browser</span>
+                      )}
+                    </div>
+                    {notificationPermission === 'denied' && supportsNotifications && (
+                      <span className="text-[11px] text-rose-300">
+                        Notifications are blocked. Update your browser settings to enable alerts.
+                      </span>
+                    )}
+                  </div>
                 </div>
-                {pushServerConnected === false && (
-                  <span className="text-[11px] text-rose-300">
-                    Unable to reach the push server. Start the backend service to deliver notifications.
-                  </span>
-                )}
-              </div>
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">Notifications</span>
-                  {supportsNotifications ? (
-                    notificationPermission === 'granted' ? (
-                      <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-[11px] font-semibold text-emerald-300">Enabled</span>
-                    ) : (
+                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="symbol" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Crypto
+                    </label>
+                    <input
+                      id="symbol"
+                      type="text"
+                      value={symbol}
+                      onChange={(event) =>
+                        onSymbolChange(event.target.value.replace(/[^a-z0-9]/gi, '').toUpperCase())
+                      }
+                      placeholder="e.g. BTCUSDT"
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium uppercase tracking-wide text-white shadow focus:border-indigo-400 focus:outline-none"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="timeframe" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Timeframe
+                    </label>
+                    <select
+                      id="timeframe"
+                      value={timeframe}
+                      onChange={(event) => onTimeframeChange(event.target.value)}
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    >
+                      {timeframeOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="bar-count" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Bars
+                    </label>
+                    <select
+                      id="bar-count"
+                      value={barSelection}
+                      onChange={(event) => onBarSelectionChange(event.target.value)}
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    >
+                      {barCountOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {barSelection === 'custom' && (
+                    <div className="flex flex-col gap-2">
+                      <label htmlFor="custom-bar-count" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                        Custom bars
+                      </label>
+                      <input
+                        id="custom-bar-count"
+                        inputMode="numeric"
+                        value={customBarCount}
+                        onChange={(event) => onCustomBarCountChange(event.target.value.replace(/[^0-9]/g, ''))}
+                        placeholder={`Max ${maxBarLimit}`}
+                        className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                      />
+                    </div>
+                  )}
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="refresh-interval" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Auto refresh
+                    </label>
+                    <select
+                      id="refresh-interval"
+                      value={refreshSelection}
+                      onChange={(event) => onRefreshSelectionChange(event.target.value)}
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    >
+                      {refreshOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {refreshSelection === 'custom' && (
+                    <div className="flex flex-col gap-2">
+                      <label htmlFor="custom-refresh" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                        Custom refresh (minutes)
+                      </label>
+                      <input
+                        id="custom-refresh"
+                        inputMode="numeric"
+                        value={customRefresh}
+                        onChange={(event) => onCustomRefreshChange(event.target.value.replace(/[^0-9]/g, ''))}
+                        placeholder="e.g. 5"
+                        className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                      />
+                    </div>
+                  )}
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="rsi-lower-bound" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      RSI lower bound
+                    </label>
+                    <input
+                      id="rsi-lower-bound"
+                      inputMode="numeric"
+                      value={rsiLowerBoundInput}
+                      onChange={(event) =>
+                        onRsiLowerBoundInputChange(event.target.value.replace(/[^0-9.]/g, ''))
+                      }
+                      placeholder="30"
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="rsi-upper-bound" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      RSI upper bound
+                    </label>
+                    <input
+                      id="rsi-upper-bound"
+                      inputMode="numeric"
+                      value={rsiUpperBoundInput}
+                      onChange={(event) =>
+                        onRsiUpperBoundInputChange(event.target.value.replace(/[^0-9.]/g, ''))
+                      }
+                      placeholder="70"
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="stochastic-lower-bound" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Stochastic RSI lower bound
+                    </label>
+                    <input
+                      id="stochastic-lower-bound"
+                      inputMode="numeric"
+                      value={stochasticLowerBoundInput}
+                      onChange={(event) =>
+                        onStochasticLowerBoundInputChange(event.target.value.replace(/[^0-9.]/g, ''))
+                      }
+                      placeholder="20"
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label htmlFor="stochastic-upper-bound" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                      Stochastic RSI upper bound
+                    </label>
+                    <input
+                      id="stochastic-upper-bound"
+                      inputMode="numeric"
+                      value={stochasticUpperBoundInput}
+                      onChange={(event) =>
+                        onStochasticUpperBoundInputChange(event.target.value.replace(/[^0-9.]/g, ''))
+                      }
+                      placeholder="80"
+                      className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+                    />
+                  </div>
+                </div>
+                <div className="grid gap-6 rounded-2xl border border-white/10 bg-slate-950/60 p-5">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="flex flex-col gap-1">
+                      <span className="text-xs uppercase tracking-wider text-slate-400">RSI thresholds</span>
+                      <span className="text-sm text-slate-300">
+                        Long ≤ {formatThreshold(momentumThresholds.longRsi)} · Short ≥ {formatThreshold(momentumThresholds.shortRsi)}
+                      </span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <span className="text-xs uppercase tracking-wider text-slate-400">Stoch RSI thresholds</span>
+                      <span className="text-sm text-slate-300">
+                        Long ≤ {formatThreshold(momentumThresholds.longStochastic)} · Short ≥ {formatThreshold(momentumThresholds.shortStochastic)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">Momentum alerts</span>
                       <button
                         type="button"
-                        onClick={() => void onEnableNotifications()}
-                        className="rounded-full border border-indigo-400/60 px-3 py-1 text-[11px] font-semibold text-indigo-100 transition hover:border-indigo-300 hover:text-white"
+                        onClick={onClearNotifications}
+                        className="text-xs text-indigo-200 transition hover:text-white"
                       >
-                        Enable alerts
+                        Clear all
                       </button>
-                    )
-                  ) : (
-                    <span className="text-[11px] text-slate-500">Not supported in this browser</span>
-                  )}
-                </div>
-                {notificationPermission === 'denied' && supportsNotifications && (
-                  <span className="text-[11px] text-rose-300">
-                    Notifications are blocked. Update your browser settings to enable alerts.
-                  </span>
-                )}
-              </div>
-            </div>
-            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
-              <div className="flex flex-col gap-2">
-                <label htmlFor="symbol" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Crypto
-                </label>
-                <input
-                  id="symbol"
-                  type="text"
-                  value={symbol}
-                  onChange={(event) =>
-                    onSymbolChange(event.target.value.replace(/[^a-z0-9]/gi, '').toUpperCase())
-                  }
-                  placeholder="e.g. BTCUSDT"
-                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium uppercase tracking-wide text-white shadow focus:border-indigo-400 focus:outline-none"
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <label htmlFor="timeframe" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Timeframe
-                </label>
-                <select
-                  id="timeframe"
-                  value={timeframe}
-                  onChange={(event) => onTimeframeChange(event.target.value)}
-                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                >
-                  {timeframeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="flex flex-col gap-2">
-                <label htmlFor="bar-count" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Bars
-                </label>
-                <select
-                  id="bar-count"
-                  value={barSelection}
-                  onChange={(event) => onBarSelectionChange(event.target.value)}
-                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                >
-                  {barCountOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-                {barSelection === 'custom' && (
-                  <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        min={1}
-                        max={maxBarLimit}
-                        value={customBarCount}
-                        onChange={(event) => onCustomBarCountChange(event.target.value)}
-                        className="w-24 rounded-xl border border-white/10 bg-slate-950/80 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none"
-                      />
-                      <span className="text-xs text-slate-400">bars</span>
                     </div>
-                    <span className="text-[11px] text-slate-500">Max {maxBarLimit}</span>
-                  </div>
-                )}
-              </div>
-              <div className="flex flex-col gap-2">
-                <label htmlFor="refresh-interval" className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  Refresh
-                </label>
-                <select
-                  id="refresh-interval"
-                  value={refreshSelection}
-                  onChange={(event) => onRefreshSelectionChange(event.target.value)}
-                  className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                >
-                  {refreshOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-                {refreshSelection === 'custom' && (
-                  <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        min={1}
-                        max={60}
-                        value={customRefresh}
-                        onChange={(event) => onCustomRefreshChange(event.target.value)}
-                        className="w-24 rounded-xl border border-white/10 bg-slate-950/80 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none"
-                      />
-                      <span className="text-xs text-slate-400">minutes</span>
+                    <div className="flex flex-col gap-2 text-xs text-slate-300">
+                      {visibleMomentumNotifications.length === 0 ? (
+                        <p>No recent momentum alerts.</p>
+                      ) : (
+                        visibleMomentumNotifications.slice(0, 3).map((notification) => (
+                          <div key={notification.id} className="flex flex-col">
+                            <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                              {notification.label}
+                            </span>
+                            <span>{notification.symbol}</span>
+                          </div>
+                        ))
+                      )}
                     </div>
-                    <span className="text-[11px] text-slate-500">Max 60 minutes</span>
                   </div>
-                )}
-              </div>
-            </div>
-            <div className="grid gap-6 rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="momentum-rsi-long" className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                    RSI long ≤
-                  </label>
-                  <input
-                    id="momentum-rsi-long"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.1"
-                    value={rsiLowerBoundInput}
-                    onChange={(event) => onRsiLowerBoundInputChange(event.target.value)}
-                    className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                  />
+                  <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">Moving average alerts</span>
+                      <button
+                        type="button"
+                        onClick={onClearNotifications}
+                        className="text-xs text-indigo-200 transition hover:text-white"
+                      >
+                        Clear all
+                      </button>
+                    </div>
+                    <div className="flex flex-col gap-2 text-xs text-slate-300">
+                      {visibleMovingAverageNotifications.length === 0 ? (
+                        <p>No moving average alerts.</p>
+                      ) : (
+                        visibleMovingAverageNotifications.slice(0, 3).map((notification) => (
+                          <div key={notification.id} className="flex flex-col">
+                            <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                              {notification.direction === 'golden' ? 'Golden cross' : 'Death cross'}
+                            </span>
+                            <span>{notification.symbol}</span>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </div>
                 </div>
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="momentum-rsi-short" className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                    RSI short ≥
-                  </label>
-                  <input
-                    id="momentum-rsi-short"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.1"
-                    value={rsiUpperBoundInput}
-                    onChange={(event) => onRsiUpperBoundInputChange(event.target.value)}
-                    className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="momentum-stoch-long" className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                    Stoch %D long ≤
-                  </label>
-                  <input
-                    id="momentum-stoch-long"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.1"
-                    value={stochasticLowerBoundInput}
-                    onChange={(event) => onStochasticLowerBoundInputChange(event.target.value)}
-                    className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label htmlFor="momentum-stoch-short" className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                    Stoch %D short ≥
-                  </label>
-                  <input
-                    id="momentum-stoch-short"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.1"
-                    value={stochasticUpperBoundInput}
-                    onChange={(event) => onStochasticUpperBoundInputChange(event.target.value)}
-                    className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
-                  />
-                </div>
-              </div>
-              <span className="text-[11px] text-slate-500">
-                Long triggers when RSI ≤ {formatThreshold(momentumThresholds.longRsi)} and Stoch RSI %D ≤ {formatThreshold(momentumThresholds.longStochastic)}. Short triggers when RSI ≥ {formatThreshold(momentumThresholds.shortRsi)} and Stoch RSI %D ≥ {formatThreshold(momentumThresholds.shortStochastic)}.
-              </span>
-            </div>
+              </>
+            )}
           </section>
-          {!isLoading && !isError && (
+          {!isSidebarCollapsed && !isLoading && !isError && (
             <section className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-900/60 p-6">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex flex-col gap-1">
@@ -744,7 +828,11 @@ export function DashboardView({
             </>
           )}
         </section>
-        <aside className="flex w-full flex-col gap-6 lg:w-80 lg:flex-shrink-0 lg:sticky lg:top-28">
+        <aside
+          className={`relative flex w-full flex-col gap-6 transition-[width] duration-300 lg:sticky lg:top-28 lg:flex-shrink-0 ${
+            isRiskPanelCollapsed ? 'lg:w-16' : 'lg:w-80'
+          }`}
+        >
           <RiskManagementPanel
             currentEquity={currentEquity}
             onCurrentEquityChange={onCurrentEquityChange}

--- a/src/components/RiskManagementPanel.tsx
+++ b/src/components/RiskManagementPanel.tsx
@@ -83,17 +83,33 @@ export function RiskManagementPanel({
     .sort((a, b) => Number(a.entryTimeframe) - Number(b.entryTimeframe))
 
   return (
-    <section className="flex flex-col gap-4 rounded-3xl border border-white/5 bg-slate-900/60 p-6">
-      <div className="flex items-start justify-between gap-4">
-        <h2 className="text-base font-semibold text-white">Risk management</h2>
+    <section
+      className={`flex h-full flex-col gap-4 rounded-3xl border border-white/5 bg-slate-900/60 transition-[padding,opacity,transform] duration-300 ${
+        isCollapsed ? 'items-center gap-3 px-3 py-4' : 'p-6'
+      }`}
+    >
+      <div
+        className={`flex w-full items-center ${
+          isCollapsed ? 'justify-center' : 'justify-between'
+        } gap-3`}
+      >
+        {!isCollapsed && <h2 className="text-base font-semibold text-white">Risk management</h2>}
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-white"
+          className={`flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/60 text-xs font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-white ${
+            isCollapsed ? 'px-2 py-2' : 'px-3 py-1'
+          }`}
           aria-expanded={!isCollapsed}
         >
-          {isCollapsed ? 'Show' : 'Hide'}
-          <span aria-hidden="true">{isCollapsed ? '▾' : '▴'}</span>
+          <span className="sr-only">
+            {isCollapsed ? 'Show risk management panel' : 'Hide risk management panel'}
+          </span>
+          <span aria-hidden="true" className="text-lg leading-none">
+            {isCollapsed ? '⟨' : '⟩'}
+          </span>
+          {!isCollapsed && <span aria-hidden="true">Hide</span>}
+          {isCollapsed && <span aria-hidden="true" className="text-[11px]">Show</span>}
         </button>
       </div>
       {!isCollapsed && (

--- a/src/components/RiskManagementPanel.tsx
+++ b/src/components/RiskManagementPanel.tsx
@@ -1,0 +1,211 @@
+import { type ChangeEvent, type Dispatch, type SetStateAction } from 'react'
+
+type RiskManagementPanelProps = {
+  currentEquity: string
+  onCurrentEquityChange: Dispatch<SetStateAction<string>>
+  isCollapsed: boolean
+  onToggleCollapse: () => void
+}
+
+type TypeDefinition = {
+  name: string
+  description: string
+  fields: Array<{ name: string; description: string }>
+}
+
+const TYPE_DEFINITIONS: TypeDefinition[] = [
+  {
+    name: 'CandleSet',
+    description: 'OHLC candles used to evaluate volatility and indicator context.',
+    fields: [
+      { name: 'close[]', description: 'Array of candle close prices.' },
+      { name: 'high[]', description: 'Array of session highs for each bar.' },
+      { name: 'low[]', description: 'Array of session lows for each bar.' },
+      { name: 'time[]', description: 'Optional timestamps tracking each bar close.' },
+    ],
+  },
+  {
+    name: 'SignalContext',
+    description:
+      'Snapshot of the triggering signal with directional bias, volatility and filter context.',
+    fields: [
+      { name: 'symbol', description: 'Instrument identifier, e.g. "BYBIT:BTCUSDT".' },
+      { name: 'side', description: 'Proposed trade direction: LONG or SHORT.' },
+      { name: 'entryTF', description: 'Entry timeframe used for sizing calculations.' },
+      { name: 'price', description: 'Latest close price acting as the entry anchor.' },
+      { name: 'atr / atrPct', description: 'Volatility metrics in absolute and percentage terms.' },
+      { name: 'bias', description: 'Higher timeframe directional bias.' },
+      { name: 'votes', description: 'Momentum vote distribution across timeframes.' },
+      {
+        name: 'rsiHTF / rsiLTF',
+        description: 'RSI readings split across higher and lower timeframes.',
+      },
+      { name: 'stochrsi', description: 'Stochastic RSI readings and crossing events.' },
+      { name: 'filters', description: 'Moving average filters including MA200 distance.' },
+      { name: 'barTimeISO', description: 'ISO timestamp of the triggering bar.' },
+      { name: 'strengthHint', description: 'Optional pre-computed strength classification.' },
+    ],
+  },
+  {
+    name: 'RiskConfig',
+    description: 'Configuration inputs controlling base risk, ladders and throttles.',
+    fields: [
+      { name: 'baseRiskWeak/Std/StrongPct', description: 'Baseline risk budget per signal strength.' },
+      { name: 'ladders', description: 'Step weights and quantities for scaling into positions.' },
+      { name: 'slMultipliers', description: 'Stop-loss distance multipliers per ladder add.' },
+      { name: 'tpMultipliers', description: 'Take-profit brackets assigned to each ladder.' },
+      { name: 'useHardTPs', description: 'Toggle between static and trailing take-profit logic.' },
+      { name: 'volMin/MaxAtrPct', description: 'ATR bounds that throttle or boost risk exposure.' },
+      { name: 'equityTiers', description: 'Equity bands that cap maximum risk allocation.' },
+      { name: 'maxOpenRiskPctPortfolio', description: 'Portfolio level cap on simultaneous open risk.' },
+      { name: 'maxOpenPositions', description: 'Guard rail on concurrent positions.' },
+      { name: 'maxDailyLossPct', description: 'Daily loss stopper before halting new trades.' },
+      { name: 'instrumentRiskCapPct', description: 'Instrument-specific maximum allocation.' },
+      { name: 'allowPyramiding / pyramidMaxAdds', description: 'Controls additional adds after ladder completion.' },
+      { name: 'contractRoundMode', description: 'Exchange specific rounding mode for orders.' },
+      { name: 'minOrderQty / qtyStep', description: 'Minimum order size and contract increments.' },
+      { name: 'tickSize', description: 'Minimum price increment for the venue.' },
+      { name: 'drawdownThrottle', description: 'Dynamic risk reductions applied during drawdowns.' },
+    ],
+  },
+  {
+    name: 'AccountState',
+    description: 'Live account snapshot used for budgeting new trades.',
+    fields: [
+      { name: 'equity', description: 'Current account equity used for percent based sizing.' },
+      { name: 'openPositions[]', description: 'Active positions contributing to open risk.' },
+      { name: 'todayRealizedPnLPct', description: 'Realised PnL relative to start-of-day equity.' },
+      { name: 'equityPeak', description: 'Peak equity for drawdown throttle calculations.' },
+    ],
+  },
+  {
+    name: 'OpenPosition',
+    description: 'Records an existing position and its original risk.',
+    fields: [
+      { name: 'symbol / side', description: 'Instrument and direction currently held.' },
+      { name: 'entryPrice', description: 'Average entry price of the position.' },
+      { name: 'qty', description: 'Quantity or contracts held.' },
+      { name: 'riskAtOpenPct', description: 'Initial risk as a percent of account equity.' },
+    ],
+  },
+  {
+    name: 'RiskPlanStep',
+    description: 'Individual entry or add leg that composes the final position.',
+    fields: [
+      { name: 'stepIndex', description: 'Execution order of the step (1..n).' },
+      { name: 'intent', description: 'ENTER or ADD to signal scaling behaviour.' },
+      { name: 'qty', description: 'Quantity allocated to this ladder step.' },
+      { name: 'entryTrigger', description: 'Trigger condition such as breakout or retest.' },
+      { name: 'slPrice', description: 'Stop-loss price attached to the step.' },
+      { name: 'tp1Price / tp2Price', description: 'Primary take-profit objectives.' },
+    ],
+  },
+  {
+    name: 'RiskPlan',
+    description: 'Full execution plan after applying volatility and drawdown throttles.',
+    fields: [
+      { name: 'finalRiskPct', description: 'Resulting percent risk after throttles.' },
+      { name: 'riskGrade', description: 'Weak, standard or strong signal classification.' },
+      { name: 'throttleFactor', description: 'Combined multiplier from volatility and drawdown guards.' },
+      { name: 'positionSizeTotal', description: 'Total contracts planned across all steps.' },
+      { name: 'notional', description: 'Monetary exposure considering contract multiplier.' },
+      { name: 'steps[]', description: 'Ordered list of RiskPlanStep entries.' },
+      { name: 'trailingPlan', description: 'Optional trailing stop configuration.' },
+    ],
+  },
+  {
+    name: 'AlertPayload',
+    description: 'Notification payload delivered to the automation layer.',
+    fields: [
+      { name: 'signal / symbol / entry_tf', description: 'Signal direction and metadata.' },
+      { name: 'strength / bias', description: 'Momentum classification and directional bias.' },
+      { name: 'votes / rsi_htf / rsi_ltf', description: 'Momentum scores embedded in the alert.' },
+      { name: 'stochrsi / filters', description: 'Stochastic RSI state and MA filter context.' },
+      { name: 'risk_plan', description: 'Full risk plan attached to the alert.' },
+      {
+        name: 'portfolio_check',
+        description: 'Portfolio guard status and reason when trades are blocked.',
+      },
+      { name: 'timestamp / version', description: 'Alert timestamp and schema version.' },
+    ],
+  },
+]
+
+export function RiskManagementPanel({
+  currentEquity,
+  onCurrentEquityChange,
+  isCollapsed,
+  onToggleCollapse,
+}: RiskManagementPanelProps) {
+  const handleEquityChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value
+    const sanitised = rawValue.replace(/[^0-9.,]/g, '')
+    onCurrentEquityChange(sanitised)
+  }
+
+  return (
+    <section className="flex flex-col gap-4 rounded-3xl border border-white/5 bg-slate-900/60 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold text-white">Risk management</h2>
+          <p className="text-xs text-slate-400">
+            Configure sizing inputs, throttles and execution guards for automation.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-indigo-400 hover:text-white"
+          aria-expanded={!isCollapsed}
+        >
+          {isCollapsed ? 'Show' : 'Hide'}
+          <span aria-hidden="true">{isCollapsed ? '▾' : '▴'}</span>
+        </button>
+      </div>
+      {!isCollapsed && (
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="current-equity"
+              className="text-xs font-semibold uppercase tracking-wider text-slate-400"
+            >
+              Current equity
+            </label>
+            <input
+              id="current-equity"
+              inputMode="decimal"
+              value={currentEquity}
+              onChange={handleEquityChange}
+              placeholder="e.g. 25,000"
+              className="rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm font-medium text-white shadow focus:border-indigo-400 focus:outline-none"
+            />
+            <p className="text-[11px] text-slate-500">
+              Persisted locally to reuse between sessions and position calculations.
+            </p>
+          </div>
+          <div className="flex flex-col gap-5">
+            {TYPE_DEFINITIONS.map((definition) => (
+              <div key={definition.name} className="flex flex-col gap-2 rounded-2xl border border-white/5 bg-slate-950/50 p-4">
+                <div className="flex flex-col gap-1">
+                  <span className="text-sm font-semibold text-white">{definition.name}</span>
+                  <p className="text-xs text-slate-400">{definition.description}</p>
+                </div>
+                <ul className="flex flex-col gap-1 text-[11px] text-slate-300">
+                  {definition.fields.map((field) => (
+                    <li key={field.name} className="flex items-start gap-2">
+                      <span className="mt-0.5 text-slate-500">•</span>
+                      <span>
+                        <span className="font-semibold text-white/90">{field.name}</span>
+                        <span className="text-slate-400"> — {field.description}</span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a collapsible risk management panel to the dashboard sidebar with documentation of key risk types
- store the new current equity input alongside existing filters for reuse between sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd068194bc8320a591afeef347d196