### PR TITLE
Refactor risk calculations into shared helper

### DIFF
--- a/core/risk-presets.js
+++ b/core/risk-presets.js
@@ -1,0 +1,176 @@
+import { RISK_CONSTANTS } from './risk.js'
+
+const DEFAULT_LADDER_WEIGHTS = [0.5, 0.3, 0.2]
+const DEFAULT_DRAWNDOWN_THRESHOLDS = [5, 10, 15]
+const DEFAULT_DRAWNDOWN_FACTORS = [0.7, 0.5, 0.3]
+const DEFAULT_EQUITY_TIERS = [
+  { min: 0, max: 25_000, capPct: 1 },
+  { min: 25_000, max: Number.MAX_SAFE_INTEGER, capPct: 1 },
+]
+
+const DEFAULT_ACCOUNT_STATE = {
+  equityPeak: 100_000,
+  equity: 100_000,
+  openPositions: [],
+  todayRealizedPnLPct: 0,
+}
+
+function clonePositions(positions) {
+  if (!Array.isArray(positions)) {
+    return []
+  }
+
+  return positions
+    .map((position) => ({
+      riskAtOpenPct: Number.isFinite(position?.riskAtOpenPct)
+        ? position.riskAtOpenPct
+        : 0,
+    }))
+    .filter((position) => Number.isFinite(position.riskAtOpenPct))
+}
+
+function resolveBaseRiskPct(value, fallback) {
+  if (!Number.isFinite(value)) {
+    return fallback
+  }
+
+  if (value <= 0) {
+    return fallback
+  }
+
+  return value
+}
+
+export function createDefaultAccountState(overrides = {}) {
+  const base = {
+    ...DEFAULT_ACCOUNT_STATE,
+    openPositions: clonePositions(DEFAULT_ACCOUNT_STATE.openPositions),
+  }
+
+  const next = { ...base, ...overrides }
+
+  if (Number.isFinite(overrides?.equityPeak) && overrides.equityPeak > 0) {
+    next.equityPeak = overrides.equityPeak
+  }
+
+  if (Number.isFinite(overrides?.equity) && overrides.equity > 0) {
+    next.equity = overrides.equity
+  }
+
+  next.openPositions = clonePositions(overrides?.openPositions ?? [])
+
+  if (Number.isFinite(overrides?.todayRealizedPnLPct)) {
+    next.todayRealizedPnLPct = overrides.todayRealizedPnLPct
+  }
+
+  return next
+}
+
+export function createRiskConfigFromHeatmapConfig(config, overrides = {}) {
+  if (!config || typeof config !== 'object') {
+    return { ...overrides }
+  }
+
+  const riskPct = Number.isFinite(config.riskPctPerTrade)
+    ? config.riskPctPerTrade * 100
+    : 0.75
+  const atrMultSl = Number.isFinite(config.atrMultSl) ? config.atrMultSl : 1.2
+  const tp1 = Number.isFinite(config.atrMultTp1) ? config.atrMultTp1 : 1
+  const tp2 = Number.isFinite(config.atrMultTp2) ? config.atrMultTp2 : tp1
+
+  const baseRiskWeakPct = resolveBaseRiskPct(overrides?.baseRiskWeakPct, riskPct)
+  const baseRiskStdPct = resolveBaseRiskPct(overrides?.baseRiskStdPct, riskPct)
+  const baseRiskStrongPct = resolveBaseRiskPct(
+    overrides?.baseRiskStrongPct,
+    Math.max(riskPct, baseRiskStdPct),
+  )
+
+  const defaultConfig = {
+    baseRiskWeakPct,
+    baseRiskStdPct,
+    baseRiskStrongPct,
+    volMaxAtrPct: Number.isFinite(config.volMaxAtrPct)
+      ? config.volMaxAtrPct
+      : overrides?.volMaxAtrPct ?? 3,
+    volMinAtrPct: Number.isFinite(config.volMinAtrPct)
+      ? config.volMinAtrPct
+      : overrides?.volMinAtrPct ?? 0.15,
+    volHighCutFactor: overrides?.volHighCutFactor ?? 0.6,
+    volLowBoostFactor: overrides?.volLowBoostFactor ?? 1.2,
+    drawdownThrottle: {
+      thresholds:
+        Array.isArray(overrides?.drawdownThrottle?.thresholds) &&
+        overrides.drawdownThrottle.thresholds.length > 0
+          ? overrides.drawdownThrottle.thresholds
+          : DEFAULT_DRAWNDOWN_THRESHOLDS,
+      factors:
+        Array.isArray(overrides?.drawdownThrottle?.factors) &&
+        overrides.drawdownThrottle.factors.length > 0
+          ? overrides.drawdownThrottle.factors
+          : DEFAULT_DRAWNDOWN_FACTORS,
+    },
+    equityTiers:
+      Array.isArray(overrides?.equityTiers) && overrides.equityTiers.length > 0
+        ? overrides.equityTiers
+        : DEFAULT_EQUITY_TIERS.map((tier) => ({ ...tier, capPct: riskPct })),
+    atrMultSl,
+    atrMultTp1: tp1,
+    atrMultTp2: tp2,
+    instrumentRiskCapPct:
+      Number.isFinite(overrides?.instrumentRiskCapPct) &&
+      overrides.instrumentRiskCapPct > 0
+        ? overrides.instrumentRiskCapPct
+        : riskPct,
+    maxOpenRiskPctPortfolio:
+      Number.isFinite(overrides?.maxOpenRiskPctPortfolio) &&
+      overrides.maxOpenRiskPctPortfolio > 0
+        ? overrides.maxOpenRiskPctPortfolio
+        : riskPct * 4,
+    maxOpenPositions:
+      Number.isFinite(overrides?.maxOpenPositions) && overrides.maxOpenPositions > 0
+        ? overrides.maxOpenPositions
+        : 4,
+    maxDailyLossPct:
+      Number.isFinite(overrides?.maxDailyLossPct) && overrides.maxDailyLossPct > 0
+        ? overrides.maxDailyLossPct
+        : riskPct * 3,
+    ladders:
+      overrides?.ladders && typeof overrides.ladders === 'object'
+        ? overrides.ladders
+        : { steps: DEFAULT_LADDER_WEIGHTS.length, weights: DEFAULT_LADDER_WEIGHTS },
+    slMultipliers:
+      Array.isArray(overrides?.slMultipliers) && overrides.slMultipliers.length > 0
+        ? overrides.slMultipliers
+        : new Array(DEFAULT_LADDER_WEIGHTS.length).fill(atrMultSl),
+    tpMultipliers:
+      Array.isArray(overrides?.tpMultipliers) && overrides.tpMultipliers.length > 0
+        ? overrides.tpMultipliers
+        : new Array(DEFAULT_LADDER_WEIGHTS.length).fill([tp1, tp2]),
+    qtyStep:
+      Number.isFinite(overrides?.qtyStep) && overrides.qtyStep > 0
+        ? overrides.qtyStep
+        : 0.001,
+    contractRoundMode:
+      overrides?.contractRoundMode ?? RISK_CONSTANTS.ROUND_MODES.NEAREST,
+    minOrderQty:
+      Number.isFinite(overrides?.minOrderQty) && overrides.minOrderQty >= 0
+        ? overrides.minOrderQty
+        : 0,
+    useHardTPs: overrides?.useHardTPs ?? false,
+    trailingAtrMultiplier:
+      Number.isFinite(overrides?.trailingAtrMultiplier) &&
+      overrides.trailingAtrMultiplier > 0
+        ? overrides.trailingAtrMultiplier
+        : Math.max(tp1, 1.5),
+  }
+
+  return {
+    ...defaultConfig,
+    ...overrides,
+    drawdownThrottle: {
+      ...defaultConfig.drawdownThrottle,
+      ...(overrides?.drawdownThrottle ?? {}),
+    },
+    equityTiers: overrides?.equityTiers ?? defaultConfig.equityTiers,
+  }
+}

--- a/core/risk.js
+++ b/core/risk.js
@@ -1,0 +1,222 @@
+const ROUND_MODES = {
+  ROUND_DOWN: 'round_down',
+  NEAREST: 'nearest',
+}
+
+const SIDES = {
+  LONG: 'LONG',
+  SHORT: 'SHORT',
+}
+
+const OPERATIONS = {
+  ADD: '+',
+  SUBTRACT: '-',
+}
+
+export function clamp(x, lo, hi) {
+  if (!Number.isFinite(x)) {
+    return lo
+  }
+
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+    throw new Error('clamp bounds must be finite numbers')
+  }
+
+  if (lo > hi) {
+    throw new Error('clamp lower bound must be <= upper bound')
+  }
+
+  return Math.min(Math.max(x, lo), hi)
+}
+
+export function roundQty(qty, step, mode = ROUND_MODES.NEAREST) {
+  if (!Number.isFinite(qty)) {
+    return NaN
+  }
+
+  if (!Number.isFinite(step) || step <= 0) {
+    return qty
+  }
+
+  const ratio = qty / step
+
+  if (mode === ROUND_MODES.ROUND_DOWN) {
+    return Math.floor(ratio) * step
+  }
+
+  return Math.round(ratio) * step
+}
+
+export function priceForSide(base, delta, side, op) {
+  if (!Number.isFinite(base) || !Number.isFinite(delta)) {
+    return null
+  }
+
+  const normalizedSide = side === SIDES.SHORT ? SIDES.SHORT : SIDES.LONG
+  const normalizedOp = op === OPERATIONS.SUBTRACT ? OPERATIONS.SUBTRACT : OPERATIONS.ADD
+
+  if (normalizedSide === SIDES.LONG) {
+    return normalizedOp === OPERATIONS.SUBTRACT ? base - delta : base + delta
+  }
+
+  return normalizedOp === OPERATIONS.SUBTRACT ? base + delta : base - delta
+}
+
+export function riskGradeFromSignal(ctx) {
+  const votes = ctx?.votes ?? {}
+  const bull = Number.isFinite(votes.bull) ? votes.bull : 0
+  const bear = Number.isFinite(votes.bear) ? votes.bear : 0
+  const total = Number.isFinite(votes.total) ? votes.total : bull + bear
+
+  if (total <= 0) {
+    return 'weak'
+  }
+
+  const maSlopeOk = ctx?.maSlopeOk ?? true
+  const aligned = maSlopeOk && (bull === total || bear === total)
+
+  if (aligned) {
+    return 'strong'
+  }
+
+  const majority = bull > bear || bear > bull
+  return majority ? 'standard' : 'weak'
+}
+
+export function baseRiskPctFromGrade(grade, cfg) {
+  if (!cfg) {
+    return 0
+  }
+
+  switch (grade) {
+    case 'weak':
+      return cfg.baseRiskWeakPct ?? 0
+    case 'standard':
+      return cfg.baseRiskStdPct ?? 0
+    case 'strong':
+      return cfg.baseRiskStrongPct ?? 0
+    default:
+      return 0
+  }
+}
+
+export function volatilityThrottle(atrPct, cfg) {
+  if (!cfg || !Number.isFinite(atrPct)) {
+    return 0
+  }
+
+  const { volMaxAtrPct, volMinAtrPct, volHighCutFactor = 1, volLowBoostFactor = 1 } = cfg
+
+  if (!Number.isFinite(volMaxAtrPct) || !Number.isFinite(volMinAtrPct)) {
+    return 0
+  }
+
+  if (atrPct > volMaxAtrPct || atrPct < volMinAtrPct) {
+    return 0
+  }
+
+  if (atrPct > volMaxAtrPct * 0.66) {
+    return volHighCutFactor
+  }
+
+  if (atrPct < volMinAtrPct * 1.5) {
+    return volLowBoostFactor
+  }
+
+  return 1
+}
+
+export function drawdownThrottle(account, cfg) {
+  if (!account || !cfg || !cfg.drawdownThrottle) {
+    return 1
+  }
+
+  const { equityPeak, equity } = account
+  if (!Number.isFinite(equityPeak) || !Number.isFinite(equity) || equityPeak <= 0) {
+    return 1
+  }
+
+  const ddPct = ((equityPeak - equity) / equityPeak) * 100
+  const thresholds = Array.isArray(cfg.drawdownThrottle.thresholds)
+    ? cfg.drawdownThrottle.thresholds
+    : []
+  const factors = Array.isArray(cfg.drawdownThrottle.factors)
+    ? cfg.drawdownThrottle.factors
+    : []
+
+  let factor = 1
+
+  for (let i = 0; i < thresholds.length && i < factors.length; i += 1) {
+    if (ddPct >= thresholds[i]) {
+      factor *= factors[i]
+    }
+  }
+
+  return clamp(factor, 0, 1)
+}
+
+export function equityTierCap(account, cfg) {
+  if (!account || !cfg || !Array.isArray(cfg.equityTiers)) {
+    return 100
+  }
+
+  const { equity } = account
+  if (!Number.isFinite(equity)) {
+    return cfg.equityTiers[cfg.equityTiers.length - 1]?.capPct ?? 100
+  }
+
+  for (const tier of cfg.equityTiers) {
+    if (equity >= tier.min && equity < tier.max) {
+      return tier.capPct
+    }
+  }
+
+  const fallbackTier = cfg.equityTiers[cfg.equityTiers.length - 1]
+  return fallbackTier?.capPct ?? 100
+}
+
+export function portfolioOpenRiskPct(account) {
+  if (!account || !Array.isArray(account.openPositions)) {
+    return 0
+  }
+
+  return account.openPositions.reduce((sum, position) => {
+    const value = Number.isFinite(position?.riskAtOpenPct)
+      ? position.riskAtOpenPct
+      : 0
+    return sum + value
+  }, 0)
+}
+
+export function buildAtrRiskLevels(price, atr, config) {
+  if (!Number.isFinite(price) || !Number.isFinite(atr) || !config) {
+    return null
+  }
+
+  const slDelta = (config.atrMultSl ?? 0) * atr
+  const tp1Delta = (config.atrMultTp1 ?? 0) * atr
+  const tp2Delta = (config.atrMultTp2 ?? 0) * atr
+
+  return {
+    atr,
+    mSL: config.atrMultSl ?? null,
+    mTP: [config.atrMultTp1 ?? null, config.atrMultTp2 ?? null],
+    risk$: null,
+    long: {
+      SL: priceForSide(price, slDelta, SIDES.LONG, OPERATIONS.SUBTRACT),
+      T1: priceForSide(price, tp1Delta, SIDES.LONG, OPERATIONS.ADD),
+      T2: priceForSide(price, tp2Delta, SIDES.LONG, OPERATIONS.ADD),
+    },
+    short: {
+      SL: priceForSide(price, slDelta, SIDES.SHORT, OPERATIONS.SUBTRACT),
+      T1: priceForSide(price, tp1Delta, SIDES.SHORT, OPERATIONS.ADD),
+      T2: priceForSide(price, tp2Delta, SIDES.SHORT, OPERATIONS.ADD),
+    },
+  }
+}
+
+export const RISK_CONSTANTS = {
+  ROUND_MODES,
+  SIDES,
+  OPERATIONS,
+}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -4,6 +4,7 @@ import type {
   MomentumNotification,
   MovingAverageCrossNotification,
   MovingAverageMarker,
+  HeatmapNotification,
 } from '../App'
 import { LineChart } from './LineChart'
 import { RiskManagementPanel } from './RiskManagementPanel'
@@ -27,6 +28,37 @@ const MOMENTUM_CARD_CLASSES: Record<MomentumIntensity, string> = {
 const MOVING_AVERAGE_DIRECTION_LABELS: Record<'golden' | 'death', string> = {
   golden: 'Golden cross',
   death: 'Death cross',
+}
+
+const HEATMAP_CARD_CLASS_BY_STRENGTH: Record<string, string> = {
+  weak: MOMENTUM_CARD_CLASSES.green,
+  standard: MOMENTUM_CARD_CLASSES.yellow,
+  strong: MOMENTUM_CARD_CLASSES.orange,
+}
+
+const HEATMAP_DEFAULT_CARD_CLASS =
+  'border-indigo-400/40 bg-indigo-500/10 text-indigo-100'
+
+const HEATMAP_EMOJI_BY_DIRECTION: Record<'LONG' | 'SHORT', string> = {
+  LONG: '🟢',
+  SHORT: '🔴',
+}
+
+function getHeatmapCardClass(strength: string | null | undefined): string {
+  if (!strength) {
+    return HEATMAP_DEFAULT_CARD_CLASS
+  }
+
+  const normalized = strength.toLowerCase()
+  return HEATMAP_CARD_CLASS_BY_STRENGTH[normalized] ?? HEATMAP_DEFAULT_CARD_CLASS
+}
+
+function formatBlockedReason(reason: string | null | undefined): string {
+  if (typeof reason !== 'string' || reason.length === 0) {
+    return 'check limits'
+  }
+
+  return reason.replace(/_/g, ' ')
 }
 
 type DashboardViewProps = {
@@ -84,9 +116,11 @@ type DashboardViewProps = {
   }
   visibleMovingAverageNotifications: MovingAverageCrossNotification[]
   visibleMomentumNotifications: MomentumNotification[]
+  visibleHeatmapNotifications: HeatmapNotification[]
   formatTriggeredAt: (timestamp: number) => string
   onDismissMovingAverageNotification: (notificationId: string) => void
   onDismissMomentumNotification: (notificationId: string) => void
+  onDismissHeatmapNotification: (notificationId: string) => void
   onClearNotifications: () => void
   lastUpdatedLabel: string
   refreshInterval: number | false
@@ -162,9 +196,11 @@ export function DashboardView({
   momentumThresholds,
   visibleMovingAverageNotifications,
   visibleMomentumNotifications,
+  visibleHeatmapNotifications,
   formatTriggeredAt,
   onDismissMovingAverageNotification,
   onDismissMomentumNotification,
+  onDismissHeatmapNotification,
   onClearNotifications,
   lastUpdatedLabel,
   refreshInterval,
@@ -194,6 +230,11 @@ export function DashboardView({
   const allNotifications = useMemo(
     () =>
       [
+        ...visibleHeatmapNotifications.map((entry) => ({
+          type: 'heatmap' as const,
+          triggeredAt: entry.triggeredAt,
+          payload: entry,
+        })),
         ...visibleMovingAverageNotifications.map((entry) => ({
           type: 'moving-average' as const,
           triggeredAt: entry.triggeredAt,
@@ -205,11 +246,17 @@ export function DashboardView({
           payload: entry,
         })),
       ].sort((a, b) => b.triggeredAt - a.triggeredAt),
-    [visibleMomentumNotifications, visibleMovingAverageNotifications],
+    [
+      visibleMomentumNotifications,
+      visibleMovingAverageNotifications,
+      visibleHeatmapNotifications,
+    ],
   )
 
   const totalNotificationCount =
-    visibleMomentumNotifications.length + visibleMovingAverageNotifications.length
+    visibleMomentumNotifications.length +
+    visibleMovingAverageNotifications.length +
+    visibleHeatmapNotifications.length
 
   const handleToggleNotifications = () => {
     if (totalNotificationCount === 0) {
@@ -284,6 +331,53 @@ export function DashboardView({
                       <p className="text-xs text-slate-500">No notifications available.</p>
                     ) : (
                       allNotifications.map((notification) => {
+                        if (notification.type === 'heatmap') {
+                          const entry = notification.payload
+                          const cardClasses = getHeatmapCardClass(
+                            typeof entry.strength === 'string' ? entry.strength : null,
+                          )
+                          const emoji = HEATMAP_EMOJI_BY_DIRECTION[entry.direction] ?? '🔥'
+                          const riskPlan = entry.alert.risk_plan
+                          const riskSummary = riskPlan
+                            ? `${riskPlan.finalRiskPct.toFixed(2)}% risk`
+                            : `Blocked (${formatBlockedReason(entry.alert.portfolio_check.reason)})`
+                          const portfolioRiskLabel = Number.isFinite(
+                            entry.alert.portfolio_check.portfolioOpenRiskPct,
+                          )
+                            ? `${entry.alert.portfolio_check.portfolioOpenRiskPct.toFixed(2)}%`
+                            : '—'
+
+                          return (
+                            <div
+                              key={`heatmap-${entry.id}`}
+                              className={`flex flex-col gap-2 rounded-xl border px-3 py-2 text-xs ${cardClasses}`}
+                            >
+                              <div className="flex items-start justify-between gap-2">
+                                <span className="text-[11px] font-semibold uppercase tracking-wide">
+                                  {emoji} Heatmap {entry.direction.toLowerCase()}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() => onDismissHeatmapNotification(entry.id)}
+                                  className="flex h-5 w-5 items-center justify-center rounded-full border border-white/20 text-xs text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+                                  aria-label="Dismiss heatmap notification"
+                                >
+                                  ×
+                                </button>
+                              </div>
+                              <span className="text-sm font-semibold text-white">{entry.symbol}</span>
+                              <span className="text-[11px] text-white/80">
+                                {entry.entryLabel} • Strength {entry.strength ?? '—'}
+                              </span>
+                              <span className="text-[11px] text-white/80">{riskSummary}</span>
+                              <span className="text-[11px] text-white/80">
+                                Portfolio open risk {portfolioRiskLabel}
+                              </span>
+                              <span className="text-[10px] text-white/60">{formatTriggeredAt(entry.triggeredAt)}</span>
+                            </div>
+                          )
+                        }
+
                         if (notification.type === 'moving-average') {
                           const entry = notification.payload
                           const cardClasses = MOMENTUM_CARD_CLASSES[entry.intensity]

--- a/src/lib/risk-presets.ts
+++ b/src/lib/risk-presets.ts
@@ -1,0 +1,4 @@
+export {
+  createDefaultAccountState,
+  createRiskConfigFromHeatmapConfig,
+} from '../../core/risk-presets.js'

--- a/src/lib/risk.ts
+++ b/src/lib/risk.ts
@@ -10,6 +10,9 @@ export type {
   RiskPlanResult,
   RiskPlanStep,
   RiskPlanTrailing,
+  RiskPlanError,
+  AlertPortfolioCheck,
+  AlertPayload,
 } from '../../core/risk.js'
 
 export {
@@ -23,6 +26,7 @@ export {
   equityTierCap,
   portfolioOpenRiskPct,
   computeRiskPlan,
+  buildAlert,
   buildAtrRiskLevels,
   RISK_CONSTANTS,
 } from '../../core/risk.js'

--- a/src/lib/risk.ts
+++ b/src/lib/risk.ts
@@ -1,0 +1,23 @@
+export type {
+  RoundMode,
+  TradeSide,
+  PriceOperation,
+  SignalContext,
+  RiskConfig,
+  AccountState,
+  AtrRiskLevels,
+} from '../../core/risk.js'
+
+export {
+  clamp,
+  roundQty,
+  priceForSide,
+  riskGradeFromSignal,
+  baseRiskPctFromGrade,
+  volatilityThrottle,
+  drawdownThrottle,
+  equityTierCap,
+  portfolioOpenRiskPct,
+  buildAtrRiskLevels,
+  RISK_CONSTANTS,
+} from '../../core/risk.js'

--- a/src/lib/risk.ts
+++ b/src/lib/risk.ts
@@ -6,6 +6,10 @@ export type {
   RiskConfig,
   AccountState,
   AtrRiskLevels,
+  RiskPlan,
+  RiskPlanResult,
+  RiskPlanStep,
+  RiskPlanTrailing,
 } from '../../core/risk.js'
 
 export {
@@ -18,6 +22,7 @@ export {
   drawdownThrottle,
   equityTierCap,
   portfolioOpenRiskPct,
+  computeRiskPlan,
   buildAtrRiskLevels,
   RISK_CONSTANTS,
 } from '../../core/risk.js'

--- a/src/types/core-risk.d.ts
+++ b/src/types/core-risk.d.ts
@@ -182,3 +182,23 @@ declare module '../../core/risk.js' {
     OPERATIONS: Record<'ADD' | 'SUBTRACT', PriceOperation>
   }
 }
+
+declare module '../../core/risk-presets.js' {
+  import type { AccountState, RiskConfig } from '../../core/risk.js'
+
+  export function createDefaultAccountState(
+    overrides?: Partial<AccountState>,
+  ): AccountState
+  export function createRiskConfigFromHeatmapConfig(
+    config: {
+      riskPctPerTrade?: number
+      atrMultSl?: number
+      atrMultTp1?: number
+      atrMultTp2?: number
+      volMaxAtrPct?: number
+      volMinAtrPct?: number
+      [key: string]: unknown
+    },
+    overrides?: RiskConfig,
+  ): RiskConfig
+}

--- a/src/types/core-risk.d.ts
+++ b/src/types/core-risk.d.ts
@@ -1,0 +1,86 @@
+declare module '../../core/risk.js' {
+  export type RoundMode = 'round_down' | 'nearest'
+  export type TradeSide = 'LONG' | 'SHORT'
+  export type PriceOperation = '+' | '-'
+
+  export type SignalVotes = {
+    bull: number
+    bear: number
+    total: number
+  }
+
+  export type SignalContext = {
+    votes: SignalVotes
+    maSlopeOk?: boolean | null
+  }
+
+  export type RiskConfig = {
+    baseRiskWeakPct?: number
+    baseRiskStdPct?: number
+    baseRiskStrongPct?: number
+    volMaxAtrPct?: number
+    volMinAtrPct?: number
+    volHighCutFactor?: number
+    volLowBoostFactor?: number
+    drawdownThrottle?: {
+      thresholds?: number[]
+      factors?: number[]
+    }
+    equityTiers?: Array<{
+      min: number
+      max: number
+      capPct: number
+    }>
+    atrMultSl?: number
+    atrMultTp1?: number
+    atrMultTp2?: number
+  }
+
+  export type AccountState = {
+    equityPeak: number
+    equity: number
+    openPositions: Array<{
+      riskAtOpenPct: number
+    }>
+  }
+
+  export type RiskLeg = {
+    SL: number | null
+    T1: number | null
+    T2: number | null
+  }
+
+  export type AtrRiskLevels = {
+    atr: number
+    mSL: number | null
+    mTP: Array<number | null>
+    risk$: null
+    long: RiskLeg
+    short: RiskLeg
+  }
+
+  export function clamp(x: number, lo: number, hi: number): number
+  export function roundQty(qty: number, step: number, mode?: RoundMode): number
+  export function priceForSide(
+    base: number,
+    delta: number,
+    side: TradeSide,
+    op: PriceOperation,
+  ): number | null
+  export function riskGradeFromSignal(ctx: SignalContext): 'weak' | 'standard' | 'strong'
+  export function baseRiskPctFromGrade(grade: string, cfg: RiskConfig): number
+  export function volatilityThrottle(atrPct: number, cfg: RiskConfig): number
+  export function drawdownThrottle(account: AccountState, cfg: RiskConfig): number
+  export function equityTierCap(account: AccountState, cfg: RiskConfig): number
+  export function portfolioOpenRiskPct(account: AccountState): number
+  export function buildAtrRiskLevels(
+    price: number,
+    atr: number,
+    config: RiskConfig,
+  ): AtrRiskLevels | null
+  export const RISK_CONSTANTS: {
+    ROUND_MODES: Record<'ROUND_DOWN' | 'NEAREST', RoundMode>
+    SIDES: Record<'LONG' | 'SHORT', TradeSide>
+    OPERATIONS: Record<'ADD' | 'SUBTRACT', PriceOperation>
+  }
+}

--- a/src/types/core-risk.d.ts
+++ b/src/types/core-risk.d.ts
@@ -7,16 +7,31 @@ declare module '../../core/risk.js' {
     bull: number
     bear: number
     total: number
+    [key: string]: unknown
   }
 
   export type SignalContext = {
-    votes: SignalVotes
+    votes?: SignalVotes | null
     maSlopeOk?: boolean | null
     strengthHint?: 'weak' | 'standard' | 'strong' | null
     atrPct?: number | null
     atr?: number | null
     price?: number | null
     side?: TradeSide | null
+    signal?: TradeSide | null
+    symbol?: string | null
+    entryTF?: string | null
+    entry_tf?: string | null
+    bias?: string | null
+    rsiHTF?: unknown
+    rsi_htf?: unknown
+    rsiLTF?: unknown
+    rsi_ltf?: unknown
+    stochrsi?: unknown
+    stochRsi?: unknown
+    filters?: unknown
+    barTimeISO?: string | null
+    timestamp?: string | null
   }
 
   export type RiskConfig = {
@@ -90,9 +105,9 @@ declare module '../../core/risk.js' {
     trailingPlan: RiskPlanTrailing
   }
 
-  export type RiskPlanResult =
-    | { ok: true; plan: RiskPlan }
-    | { ok: false; reason: string }
+  export type RiskPlanError = { ok: false; reason: string }
+
+  export type RiskPlanResult = { ok: true; plan: RiskPlan } | RiskPlanError
 
   export type RiskLeg = {
     SL: number | null
@@ -107,6 +122,29 @@ declare module '../../core/risk.js' {
     risk$: null
     long: RiskLeg
     short: RiskLeg
+  }
+
+  export type AlertPortfolioCheck = {
+    allowed: boolean
+    reason: string | null
+    portfolioOpenRiskPct: number
+  }
+
+  export type AlertPayload = {
+    signal: TradeSide | string | null
+    symbol: string | null
+    entry_tf: string | null
+    strength: 'weak' | 'standard' | 'strong' | string | null
+    bias: string | null
+    votes: SignalVotes | null
+    rsi_htf: unknown
+    rsi_ltf: unknown
+    stochrsi: unknown
+    filters: unknown
+    risk_plan: RiskPlan | null
+    portfolio_check: AlertPortfolioCheck
+    timestamp: string | null
+    version: string
   }
 
   export function clamp(x: number, lo: number, hi: number): number
@@ -128,6 +166,11 @@ declare module '../../core/risk.js' {
     cfg: RiskConfig,
     account: AccountState,
   ): RiskPlanResult
+  export function buildAlert(
+    ctx: SignalContext,
+    cfg: RiskConfig,
+    account: AccountState,
+  ): AlertPayload
   export function buildAtrRiskLevels(
     price: number,
     atr: number,


### PR DESCRIPTION
## Summary
- add a shared risk helper with rounding, price adjustment, throttling, and ATR-based level utilities
- replace bespoke client/server grading logic with the shared helper and reuse ATR level builder
- expose helper types for the frontend and update heatmap processing to use the new helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd17d79620832098b2c7ea4c9c5f96