### PR TITLE
Show only suggested risk plan per timeframe

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -39,9 +39,16 @@ const HEATMAP_CARD_CLASS_BY_STRENGTH: Record<string, string> = {
 const HEATMAP_DEFAULT_CARD_CLASS =
   'border-indigo-400/40 bg-indigo-500/10 text-indigo-100'
 
-const HEATMAP_EMOJI_BY_DIRECTION: Record<'LONG' | 'SHORT', string> = {
+const HEATMAP_EMOJI_BY_DIRECTION: Record<'LONG' | 'SHORT' | 'NONE', string> = {
   LONG: '🟢',
   SHORT: '🔴',
+  NONE: '⚪️',
+}
+
+const HEATMAP_STATUS_EMOJI_BY_BIAS: Record<'BULL' | 'BEAR' | 'NEUTRAL', string> = {
+  BULL: '🟢',
+  BEAR: '🔴',
+  NEUTRAL: '⚪️',
 }
 
 function getHeatmapCardClass(strength: string | null | undefined): string {
@@ -336,6 +343,41 @@ export function DashboardView({
                           const cardClasses = getHeatmapCardClass(
                             typeof entry.strength === 'string' ? entry.strength : null,
                           )
+                          if (entry.kind === 'status') {
+                            const emoji = HEATMAP_STATUS_EMOJI_BY_BIAS[entry.bias] ?? '⚪️'
+
+                            return (
+                              <div
+                                key={`heatmap-${entry.id}`}
+                                className={`flex flex-col gap-2 rounded-xl border px-3 py-2 text-xs ${cardClasses}`}
+                              >
+                                <div className="flex items-start justify-between gap-2">
+                                  <span className="text-[11px] font-semibold uppercase tracking-wide">
+                                    {emoji} Heatmap status
+                                  </span>
+                                  <button
+                                    type="button"
+                                    onClick={() => onDismissHeatmapNotification(entry.id)}
+                                    className="flex h-5 w-5 items-center justify-center rounded-full border border-white/20 text-xs text-white/70 transition hover:border-white/40 hover:bg-white/10 hover:text-white"
+                                    aria-label="Dismiss heatmap notification"
+                                  >
+                                    ×
+                                  </button>
+                                </div>
+                                <span className="text-sm font-semibold text-white">{entry.symbol}</span>
+                                <span className="text-[11px] text-white/80">{entry.entryLabel}</span>
+                                {entry.statusSummary && (
+                                  <span className="text-[11px] text-white/80">{entry.statusSummary}</span>
+                                )}
+                                <span className="text-[10px] text-white/60">{formatTriggeredAt(entry.triggeredAt)}</span>
+                              </div>
+                            )
+                          }
+
+                          if (!entry.alert) {
+                            return null
+                          }
+
                           const emoji = HEATMAP_EMOJI_BY_DIRECTION[entry.direction] ?? '🔥'
                           const riskPlan = entry.alert.risk_plan
                           const riskSummary = riskPlan

--- a/src/components/RiskManagementPanel.tsx
+++ b/src/components/RiskManagementPanel.tsx
@@ -34,11 +34,20 @@ const parseNumericInput = (value: string): number | null => {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-const formatNumber = (value: number | null, maximumFractionDigits = 2) =>
+const formatNumber = (
+  value: number | null,
+  {
+    minimumFractionDigits = 0,
+    maximumFractionDigits = 2,
+  }: {
+    minimumFractionDigits?: number
+    maximumFractionDigits?: number
+  } = {},
+) =>
   value == null || !Number.isFinite(value)
     ? '—'
     : value.toLocaleString(undefined, {
-        minimumFractionDigits: 0,
+        minimumFractionDigits,
         maximumFractionDigits,
       })
 
@@ -262,7 +271,10 @@ export function RiskManagementPanel({
                         <div>
                           <p className="text-[11px] uppercase tracking-wide text-slate-400">Price</p>
                           <p className="text-sm font-medium text-slate-200">
-                            {formatNumber(result.price)}
+                            {formatNumber(result.price, {
+                              minimumFractionDigits: 4,
+                              maximumFractionDigits: 4,
+                            })}
                           </p>
                         </div>
                         <div className="text-right">

--- a/src/components/RiskManagementPanel.tsx
+++ b/src/components/RiskManagementPanel.tsx
@@ -208,6 +208,31 @@ export function RiskManagementPanel({
                     ? result.risk.slShort - result.price
                     : null
 
+                const planMeta =
+                  result.signal === 'LONG'
+                    ? {
+                        label: 'Long plan',
+                        colorClasses:
+                          'border-emerald-400/30 bg-emerald-500/10 text-emerald-100',
+                        headerClasses: 'text-emerald-200',
+                        stop: result.risk.slLong,
+                        takeProfit1: result.risk.t1Long,
+                        takeProfit2: result.risk.t2Long,
+                        stopDistance: longStopDistance,
+                      }
+                    : result.signal === 'SHORT'
+                      ? {
+                          label: 'Short plan',
+                          colorClasses:
+                            'border-rose-400/30 bg-rose-500/10 text-rose-100',
+                          headerClasses: 'text-rose-200',
+                          stop: result.risk.slShort,
+                          takeProfit1: result.risk.t1Short,
+                          takeProfit2: result.risk.t2Short,
+                          stopDistance: shortStopDistance,
+                        }
+                      : null
+
                 return (
                   <article
                     key={`${result.entryTimeframe}-${result.symbol}`}
@@ -252,49 +277,40 @@ export function RiskManagementPanel({
                         </div>
                       </div>
 
-                      <div className="grid gap-3 sm:grid-cols-2">
-                        <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 p-3 text-sm text-emerald-100">
-                          <p className="text-[11px] uppercase tracking-wide text-emerald-200">Long plan</p>
-                          <dl className="mt-2 space-y-1">
-                            <div className="flex items-center justify-between">
-                              <dt>SL</dt>
-                              <dd>{formatNumber(result.risk.slLong)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between">
-                              <dt>TP1</dt>
-                              <dd>{formatNumber(result.risk.t1Long)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between">
-                              <dt>TP2</dt>
-                              <dd>{formatNumber(result.risk.t2Long)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between text-xs text-emerald-200/80">
-                              <dt>Risk distance</dt>
-                              <dd>{formatNumber(longStopDistance)}</dd>
-                            </div>
-                          </dl>
-                        </div>
-                        <div className="rounded-xl border border-rose-400/30 bg-rose-500/10 p-3 text-sm text-rose-100">
-                          <p className="text-[11px] uppercase tracking-wide text-rose-200">Short plan</p>
-                          <dl className="mt-2 space-y-1">
-                            <div className="flex items-center justify-between">
-                              <dt>SL</dt>
-                              <dd>{formatNumber(result.risk.slShort)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between">
-                              <dt>TP1</dt>
-                              <dd>{formatNumber(result.risk.t1Short)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between">
-                              <dt>TP2</dt>
-                              <dd>{formatNumber(result.risk.t2Short)}</dd>
-                            </div>
-                            <div className="flex items-center justify-between text-xs text-rose-200/80">
-                              <dt>Risk distance</dt>
-                              <dd>{formatNumber(shortStopDistance)}</dd>
-                            </div>
-                          </dl>
-                        </div>
+                      <div className="grid gap-3">
+                        {planMeta ? (
+                          <div
+                            className={`rounded-xl border p-3 text-sm ${planMeta.colorClasses}`}
+                          >
+                            <p
+                              className={`text-[11px] uppercase tracking-wide ${planMeta.headerClasses}`}
+                            >
+                              Suggested {planMeta.label}
+                            </p>
+                            <dl className="mt-2 space-y-1">
+                              <div className="flex items-center justify-between">
+                                <dt>SL</dt>
+                                <dd>{formatNumber(planMeta.stop)}</dd>
+                              </div>
+                              <div className="flex items-center justify-between">
+                                <dt>TP1</dt>
+                                <dd>{formatNumber(planMeta.takeProfit1)}</dd>
+                              </div>
+                              <div className="flex items-center justify-between">
+                                <dt>TP2</dt>
+                                <dd>{formatNumber(planMeta.takeProfit2)}</dd>
+                              </div>
+                              <div className="flex items-center justify-between text-xs opacity-80">
+                                <dt>Risk distance</dt>
+                                <dd>{formatNumber(planMeta.stopDistance)}</dd>
+                              </div>
+                            </dl>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-slate-400">
+                            No suggested plan for this timeframe.
+                          </p>
+                        )}
                       </div>
                     </div>
                   </article>


### PR DESCRIPTION
## Summary
- update the risk management panel to only render the suggested plan for each timeframe
- replace the dual long/short cards with a single signal-driven card and fallback messaging to avoid duplication with the heatmap

## Testing
- npm run build *(fails: existing TypeScript declaration errors in App.tsx and core bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4ae90154832083850bca479d64c6