### PR TITLE
Add trading signals panel and notifications

### DIFF
--- a/src/components/SignalsPanel.tsx
+++ b/src/components/SignalsPanel.tsx
@@ -1,0 +1,117 @@
+import { useMemo, useState } from 'react'
+import type { TradingSignal } from '../types/signals'
+
+const STRENGTH_BADGE_CLASS: Record<string, string> = {
+  weak: 'bg-emerald-500/10 text-emerald-200 border-emerald-400/40',
+  medium: 'bg-amber-500/10 text-amber-200 border-amber-400/40',
+  strong: 'bg-orange-500/10 text-orange-200 border-orange-400/40',
+}
+
+type SignalsPanelProps = {
+  signals: TradingSignal[]
+  isLoading: boolean
+}
+
+export function SignalsPanel({ signals, isLoading }: SignalsPanelProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  const normalizedSignals = useMemo(
+    () => signals.slice().sort((a, b) => b.confluenceScore - a.confluenceScore),
+    [signals],
+  )
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60">
+      <header className="flex items-center justify-between gap-3 border-b border-white/5 px-6 py-4">
+        <div className="flex flex-col">
+          <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Signals
+          </span>
+          <span className="text-sm text-slate-300">Actionable confluence across timeframes</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsCollapsed((previous) => !previous)}
+          className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-100 transition hover:border-white/20 hover:text-white"
+        >
+          {isCollapsed ? 'Expand' : 'Collapse'}
+          <span className={`transition-transform ${isCollapsed ? '' : 'rotate-180'}`}>⌃</span>
+        </button>
+      </header>
+      {!isCollapsed && (
+        <div className="flex flex-col gap-4 px-6 py-5">
+          {isLoading ? (
+            <p className="text-sm text-slate-400">Calculating signals…</p>
+          ) : normalizedSignals.length === 0 ? (
+            <p className="text-sm text-slate-400">No qualified signals yet. Check back soon.</p>
+          ) : (
+            normalizedSignals.slice(0, 6).map((signal) => {
+              const strengthKey = signal.strength.toLowerCase()
+              const badgeClass =
+                STRENGTH_BADGE_CLASS[strengthKey] ?? STRENGTH_BADGE_CLASS.weak
+
+              return (
+                <article
+                  key={`${signal.dedupeKey}-${signal.createdAt}`}
+                  className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex flex-col">
+                      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                        {signal.timeframeLabel} • {signal.side}
+                      </span>
+                      <span className="text-lg font-semibold text-white">{signal.symbol}</span>
+                    </div>
+                    <div className="flex flex-col items-end gap-2 text-right">
+                      <span
+                        className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${badgeClass}`}
+                      >
+                        {signal.strength} • {signal.confluenceScore}
+                      </span>
+                      {signal.price != null && Number.isFinite(signal.price) && (
+                        <span className="text-xs text-slate-300">Price {signal.price.toFixed(5)}</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid gap-2 text-xs text-slate-300 md:grid-cols-2">
+                    <div className="flex flex-col gap-1">
+                      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                        Reasons
+                      </span>
+                      <ul className="flex list-disc flex-col gap-1 pl-4">
+                        {signal.reason.map((reason, index) => (
+                          <li key={`${signal.dedupeKey}-reason-${index}`}>{reason}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                        Risk plan
+                      </span>
+                      <span>
+                        SL{' '}
+                        {signal.suggestedSL != null && Number.isFinite(signal.suggestedSL)
+                          ? signal.suggestedSL.toFixed(5)
+                          : '—'}
+                      </span>
+                      <span>
+                        TP{' '}
+                        {signal.suggestedTP != null && Number.isFinite(signal.suggestedTP)
+                          ? signal.suggestedTP.toFixed(5)
+                          : '—'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-wide text-slate-500">
+                    <span>Bias {signal.bias.toLowerCase()}</span>
+                    <span>Key {signal.dedupeKey}</span>
+                  </div>
+                </article>
+              )
+            })
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/signals.ts
+++ b/src/lib/signals.ts
@@ -1,0 +1,197 @@
+import type { HeatmapResult } from '../types/heatmap'
+import type { SignalDirection, SignalStrength, TradingSignal } from '../types/signals'
+
+const RSI_OVERSOLD = 35
+const RSI_OVERBOUGHT = 65
+const STOCH_LOW = 20
+const STOCH_HIGH = 80
+
+const MAX_SCORE = 100
+
+export function deriveSignalsFromHeatmap(results: HeatmapResult[]): TradingSignal[] {
+  return results
+    .map((result) => mapHeatmapResultToSignal(result))
+    .filter((signal): signal is TradingSignal => signal != null)
+    .sort((a, b) => b.createdAt - a.createdAt)
+}
+
+function mapHeatmapResultToSignal(result: HeatmapResult): TradingSignal | null {
+  if (result.signal === 'NONE') {
+    return null
+  }
+
+  const side: SignalDirection = result.signal === 'LONG' ? 'Bullish' : 'Bearish'
+  const createdAt = result.closedAt ?? result.evaluatedAt ?? Date.now()
+  const reasons = buildReasons(result, side)
+  const confluenceScore = scoreSignal(result, side, reasons)
+
+  const strength = bucketSignal(confluenceScore)
+  const suggestedSL =
+    result.signal === 'LONG' ? result.risk.slLong ?? null : result.risk.slShort ?? null
+  const suggestedTPBase =
+    result.signal === 'LONG'
+      ? result.risk.t2Long ?? result.risk.t1Long
+      : result.risk.t2Short ?? result.risk.t1Short
+  const suggestedTP = suggestedTPBase ?? null
+
+  return {
+    symbol: result.symbol,
+    tf: result.entryTimeframe,
+    timeframeLabel: result.entryLabel,
+    side,
+    reason: reasons,
+    confluenceScore,
+    strength,
+    suggestedSL,
+    suggestedTP,
+    metadata: { heatmap: result },
+    dedupeKey: `${result.symbol}|${result.entryTimeframe}|${side}`,
+    createdAt,
+    price: result.price ?? null,
+    bias: result.bias,
+  }
+}
+
+function buildReasons(result: HeatmapResult, side: SignalDirection): string[] {
+  const reasons: string[] = []
+
+  if (side === 'Bullish') {
+    if (result.gating.long.timing && result.bias === 'BULL' && result.filters.maLongOk) {
+      reasons.push('Trend & momentum aligned above MA200')
+    }
+    if (typeof result.rsiLtf.value === 'number' && result.rsiLtf.value <= RSI_OVERSOLD) {
+      reasons.push('RSI oversold')
+    }
+    if (result.stochEvent === 'cross_up_from_oversold') {
+      reasons.push('StochRSI K>D in lower band')
+    }
+  } else {
+    if (result.gating.short.timing && result.bias === 'BEAR' && result.filters.maShortOk) {
+      reasons.push('Trend & momentum aligned below MA200')
+    }
+    if (typeof result.rsiLtf.value === 'number' && result.rsiLtf.value >= RSI_OVERBOUGHT) {
+      reasons.push('RSI overbought')
+    }
+    if (result.stochEvent === 'cross_down_from_overbought') {
+      reasons.push('StochRSI K<D in upper band')
+    }
+  }
+
+  if (result.filters.atrStatus === 'ok') {
+    reasons.push('ATR filter satisfied')
+  }
+
+  if (reasons.length === 0) {
+    reasons.push('Confluence threshold met')
+  }
+
+  return reasons
+}
+
+function scoreSignal(
+  result: HeatmapResult,
+  side: SignalDirection,
+  reasons: string[],
+): number {
+  let score = 0
+
+  for (const reason of reasons) {
+    if (reason.includes('EMA10 crossed above EMA50') || reason.includes('EMA10 crossed below EMA50')) {
+      score += 20
+    }
+    if (reason.includes('Golden Cross') || reason.includes('Death Cross')) {
+      score += 25
+    }
+    if (reason.includes('RSI over')) {
+      score += 10
+    }
+    if (reason.includes('StochRSI')) {
+      score += 10
+    }
+    if (reason.includes('Trend & momentum aligned')) {
+      score += 25
+    }
+    if (reason.includes('ATR filter satisfied')) {
+      score += 5
+    }
+  }
+
+  if (result.bias === 'BULL' && side === 'Bullish') {
+    score += 10
+  }
+  if (result.bias === 'BEAR' && side === 'Bearish') {
+    score += 10
+  }
+
+  const dist = result.filters.distPctToMa200
+  if (typeof dist === 'number' && Number.isFinite(dist)) {
+    if (dist < 0.5) {
+      score += 8
+    } else if (dist < 1) {
+      score += 5
+    }
+  }
+
+  const rsi = result.rsiLtf.value
+  if (typeof rsi === 'number' && Number.isFinite(rsi)) {
+    if (side === 'Bullish' && rsi > 50) {
+      score += 8
+    }
+    if (side === 'Bearish' && rsi < 50) {
+      score += 8
+    }
+  }
+
+  const { k, d } = result.stochRsi
+  if (
+    typeof k === 'number' &&
+    typeof d === 'number' &&
+    Number.isFinite(k) &&
+    Number.isFinite(d)
+  ) {
+    if (side === 'Bullish' && k > d) {
+      score += 5
+    }
+    if (side === 'Bearish' && k < d) {
+      score += 5
+    }
+    if (side === 'Bullish' && k <= STOCH_LOW && d <= STOCH_LOW) {
+      score += 5
+    }
+    if (side === 'Bearish' && k >= STOCH_HIGH && d >= STOCH_HIGH) {
+      score += 5
+    }
+  }
+
+  const slope = result.ma200.slope
+  if (typeof slope === 'number' && Number.isFinite(slope)) {
+    if (side === 'Bullish' && slope > 0) {
+      score += 5
+    }
+    if (side === 'Bearish' && slope < 0) {
+      score += 5
+    }
+  }
+
+  return clampScore(score)
+}
+
+function bucketSignal(score: number): SignalStrength {
+  if (score >= 80) {
+    return 'Strong'
+  }
+  if (score >= 60) {
+    return 'Medium'
+  }
+  return 'Weak'
+}
+
+function clampScore(score: number): number {
+  if (score < 0) {
+    return 0
+  }
+  if (score > MAX_SCORE) {
+    return MAX_SCORE
+  }
+  return Math.round(score)
+}

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -1,0 +1,33 @@
+export type SignalDirection = 'Bullish' | 'Bearish'
+
+export type SignalStrength = 'Weak' | 'Medium' | 'Strong'
+
+export type TradingSignal = {
+  symbol: string
+  tf: string
+  timeframeLabel: string
+  side: SignalDirection
+  reason: string[]
+  confluenceScore: number
+  strength: SignalStrength
+  suggestedSL: number | null
+  suggestedTP: number | null
+  metadata: Record<string, unknown>
+  dedupeKey: string
+  createdAt: number
+  price: number | null
+  bias: 'BULL' | 'BEAR' | 'NEUTRAL'
+}
+
+export type SignalNotification = {
+  id: string
+  symbol: string
+  timeframe: string
+  timeframeLabel: string
+  side: SignalDirection
+  strength: SignalStrength
+  confluenceScore: number
+  price: number | null
+  reasons: string[]
+  triggeredAt: number
+}


### PR DESCRIPTION
## Summary
- derive structured trading signals from heatmap results and expose them across the app
- surface a collapsible Signals panel and integrate signal alerts into the dashboard UI
- add in-app and push notifications plus shared types for signal metadata

## Testing
- npm run build *(fails: missing type declarations for core risk modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5bdf43288320845d6f71132db2a5