### PR TITLE
Add combined signal helper based on indicator biases

### DIFF
--- a/src/components/SignalsPanel.tsx
+++ b/src/components/SignalsPanel.tsx
@@ -19,6 +19,12 @@ const COMBINED_STRENGTH_GRADIENT: Record<string, string> = {
   neutral: 'from-slate-500 to-slate-400',
 }
 
+const BIAS_STATUS_CLASS: Record<string, string> = {
+  bullish: 'border-emerald-400/40 bg-emerald-500/5 text-emerald-200',
+  bearish: 'border-rose-400/40 bg-rose-500/5 text-rose-200',
+  neutral: 'border-slate-400/30 bg-slate-700/20 text-slate-200',
+}
+
 type SignalsPanelProps = {
   signals: TradingSignal[]
   snapshots: TimeframeSignalSnapshot[]
@@ -138,6 +144,23 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                   snapshot.combined.breakdown
                 const formatBiasValue = (value: number) =>
                   value > 0 ? `+${value}` : value.toString()
+                const resolveBiasDirection = (value: number) => {
+                  if (value > 0) {
+                    return 'Bullish'
+                  }
+
+                  if (value < 0) {
+                    return 'Bearish'
+                  }
+
+                  return 'Neutral'
+                }
+                const biasStatuses = [
+                  { label: 'Trend', value: trendBias },
+                  { label: 'Momentum', value: momentumBias },
+                  { label: 'Confirmation', value: confirmation },
+                  { label: 'Total', value: combinedScore },
+                ]
 
                 return (
                   <article
@@ -186,21 +209,34 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                     </div>
                     <div className="flex flex-col gap-2 text-xs text-slate-300">
                       <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                        Bias breakdown
+                        Current bias status
                       </span>
-                      <div className="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide">
-                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
-                          Trend {formatBiasValue(trendBias)}
-                        </span>
-                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
-                          Momentum {formatBiasValue(momentumBias)}
-                        </span>
-                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
-                          Confirmation {formatBiasValue(confirmation)}
-                        </span>
-                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
-                          Total {formatBiasValue(combinedScore)}
-                        </span>
+                      <div className="grid grid-cols-2 gap-2 text-[11px] uppercase tracking-wide sm:grid-cols-4">
+                        {biasStatuses.map(({ label, value }) => {
+                          const direction = resolveBiasDirection(value)
+                          const directionKey = direction.toLowerCase()
+                          const badgeClass =
+                            BIAS_STATUS_CLASS[directionKey] ?? BIAS_STATUS_CLASS.neutral
+
+                          return (
+                            <div
+                              key={`${snapshot.timeframe}-${label}`}
+                              className={`flex flex-col gap-1 rounded-xl border px-3 py-2 text-left ${badgeClass}`}
+                            >
+                              <span className="text-[10px] font-semibold tracking-wide text-slate-400/80">
+                                {label}
+                              </span>
+                              <div className="flex items-baseline justify-between gap-2">
+                                <span className="text-xs font-semibold uppercase tracking-wide">
+                                  {direction.toLowerCase()}
+                                </span>
+                                <span className="font-mono text-[11px]">
+                                  {formatBiasValue(value)}
+                                </span>
+                              </div>
+                            </div>
+                          )
+                        })}
                       </div>
                     </div>
                     <div className="flex items-center justify-between text-xs text-slate-300">

--- a/src/components/SignalsPanel.tsx
+++ b/src/components/SignalsPanel.tsx
@@ -13,6 +13,12 @@ const DIRECTION_BADGE_CLASS: Record<string, string> = {
   neutral: 'border-slate-400/40 bg-slate-500/10 text-slate-200',
 }
 
+const COMBINED_STRENGTH_GRADIENT: Record<string, string> = {
+  bullish: 'from-emerald-400 to-emerald-500',
+  bearish: 'from-rose-400 to-rose-500',
+  neutral: 'from-slate-500 to-slate-400',
+}
+
 type SignalsPanelProps = {
   signals: TradingSignal[]
   snapshots: TimeframeSignalSnapshot[]
@@ -119,6 +125,15 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                   strengthKey != null
                     ? STRENGTH_BADGE_CLASS[strengthKey] ?? STRENGTH_BADGE_CLASS.weak
                     : null
+                const combinedDirectionKey = formatDirection(snapshot.combined.direction)
+                const combinedDirectionClass =
+                  DIRECTION_BADGE_CLASS[combinedDirectionKey] ?? DIRECTION_BADGE_CLASS.neutral
+                const combinedStrength = Math.round(
+                  Math.min(Math.max(snapshot.combined.strength ?? 0, 0), 100),
+                )
+                const combinedGradient =
+                  COMBINED_STRENGTH_GRADIENT[combinedDirectionKey] ??
+                  COMBINED_STRENGTH_GRADIENT.neutral
 
                 return (
                   <article
@@ -144,8 +159,29 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                         Bias {snapshot.bias.toLowerCase()}
                       </span>
                     </div>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center justify-between text-xs text-slate-300">
+                        <span>Combined signal</span>
+                        <span
+                          className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${combinedDirectionClass}`}
+                        >
+                          {formatDirection(snapshot.combined.direction)}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-slate-800">
+                          <div
+                            className={`absolute inset-y-0 left-0 bg-gradient-to-r ${combinedGradient}`}
+                            style={{ width: `${combinedStrength}%` }}
+                          />
+                        </div>
+                        <span className="text-xs font-semibold text-slate-200">
+                          {combinedStrength}%
+                        </span>
+                      </div>
+                    </div>
                     <div className="flex items-center justify-between text-xs text-slate-300">
-                      <span>Strength</span>
+                      <span>Confluence strength</span>
                       {snapshot.strength && strengthClass ? (
                         <span
                           className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${strengthClass}`}

--- a/src/components/SignalsPanel.tsx
+++ b/src/components/SignalsPanel.tsx
@@ -134,6 +134,10 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                 const combinedGradient =
                   COMBINED_STRENGTH_GRADIENT[combinedDirectionKey] ??
                   COMBINED_STRENGTH_GRADIENT.neutral
+                const { trendBias, momentumBias, confirmation, combinedScore } =
+                  snapshot.combined.breakdown
+                const formatBiasValue = (value: number) =>
+                  value > 0 ? `+${value}` : value.toString()
 
                 return (
                   <article
@@ -177,6 +181,25 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
                         </div>
                         <span className="text-xs font-semibold text-slate-200">
                           {combinedStrength}%
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2 text-xs text-slate-300">
+                      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                        Bias breakdown
+                      </span>
+                      <div className="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide">
+                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
+                          Trend {formatBiasValue(trendBias)}
+                        </span>
+                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
+                          Momentum {formatBiasValue(momentumBias)}
+                        </span>
+                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
+                          Confirmation {formatBiasValue(confirmation)}
+                        </span>
+                        <span className="rounded-full border border-slate-500/40 bg-slate-500/10 px-3 py-1 text-slate-200">
+                          Total {formatBiasValue(combinedScore)}
                         </span>
                       </div>
                     </div>

--- a/src/lib/signals.ts
+++ b/src/lib/signals.ts
@@ -83,7 +83,16 @@ export function getCombinedSignal(
     direction = 'Bearish'
   }
 
-  return { direction, strength }
+  return {
+    direction,
+    strength,
+    breakdown: {
+      trendBias,
+      momentumBias,
+      confirmation,
+      combinedScore,
+    },
+  }
 }
 
 export function deriveSignalsFromHeatmap(results: HeatmapResult[]): TradingSignal[] {

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -4,9 +4,17 @@ export type SignalStrength = 'Weak' | 'Medium' | 'Strong'
 
 export type CombinedSignalDirection = SignalDirection | 'Neutral'
 
+export type CombinedSignalBreakdown = {
+  trendBias: number
+  momentumBias: number
+  confirmation: number
+  combinedScore: number
+}
+
 export type CombinedSignal = {
   direction: CombinedSignalDirection
   strength: number
+  breakdown: CombinedSignalBreakdown
 }
 
 export type TradingSignal = {

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -2,6 +2,13 @@ export type SignalDirection = 'Bullish' | 'Bearish'
 
 export type SignalStrength = 'Weak' | 'Medium' | 'Strong'
 
+export type CombinedSignalDirection = SignalDirection | 'Neutral'
+
+export type CombinedSignal = {
+  direction: CombinedSignalDirection
+  strength: number
+}
+
 export type TradingSignal = {
   symbol: string
   tf: string
@@ -43,4 +50,5 @@ export type TimeframeSignalSnapshot = {
   bias: 'BULL' | 'BEAR' | 'NEUTRAL'
   slopeMa200: number | null
   side: SignalDirection | null
+  combined: CombinedSignal
 }

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -17,6 +17,19 @@ export type CombinedSignal = {
   breakdown: CombinedSignalBreakdown
 }
 
+export type CombinedSignalNotification = {
+  id: string
+  symbol: string
+  timeframe: string
+  timeframeLabel: string
+  direction: CombinedSignalDirection
+  strength: number
+  breakdown: CombinedSignalBreakdown
+  price: number | null
+  bias: 'BULL' | 'BEAR' | 'NEUTRAL'
+  triggeredAt: number
+}
+
 export type TradingSignal = {
   symbol: string
   tf: string


### PR DESCRIPTION
## Summary
- add a combined signal helper that weights trend, momentum, and MACD confirmation to produce direction and strength scores

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3b09960e883208d589594d3ccd4ad