### PR TITLE
Add Vitest setup and LineChart component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "push:server": "node server/index.js"
+    "push:server": "node server/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.2",
@@ -41,6 +43,12 @@
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",
     "vite-plugin-pwa": "^1.0.3",
-    "workbox-window": "^7.3.0"
+    "workbox-window": "^7.3.0",
+    "vitest": "^2.1.6",
+    "@vitest/coverage-v8": "^2.1.6",
+    "jsdom": "^26.0.0",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/user-event": "^14.5.2"
   }
 }

--- a/src/components/__tests__/LineChart.test.tsx
+++ b/src/components/__tests__/LineChart.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { LineChart } from '../LineChart'
+
+describe('LineChart', () => {
+  it('renders a fallback message when no data is provided', () => {
+    render(<LineChart title="RSI" labels={[]} />)
+
+    expect(
+      screen.getByText('No data available for this selection.'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the current value badge for a single data series', () => {
+    render(
+      <LineChart title="RSI" labels={['A', 'B', 'C']} data={[null, 123.456, 100]} />,
+    )
+
+    expect(screen.getByText('Current 100.0')).toBeInTheDocument()
+  })
+
+  it('allows collapsing and expanding the chart panel', async () => {
+    const user = userEvent.setup()
+
+    const { container } = render(
+      <LineChart title="RSI" labels={['A', 'B', 'C']} data={[0, 1, 2, 3]} />,
+    )
+
+    const toggleButton = screen.getByRole('button', { name: /collapse/i })
+
+    expect(container.querySelector('svg')).not.toBeNull()
+
+    await user.click(toggleButton)
+
+    expect(toggleButton).toHaveTextContent('Expand')
+    expect(container.querySelector('svg')).toBeNull()
+
+    await user.click(toggleButton)
+
+    expect(toggleButton).toHaveTextContent('Collapse')
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('renders loading feedback when new data is requested', () => {
+    render(
+      <LineChart
+        title="RSI"
+        labels={['A', 'B', 'C']}
+        data={[0, 1, 2]}
+        isLoading
+      />,
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('Reloading chart data…')
+  })
+
+  it('renders guideline labels and multi-series summaries', () => {
+    render(
+      <LineChart
+        title="MACD"
+        labels={['Jan', 'Feb', 'Mar']}
+        series={[
+          { name: 'MACD', data: [1, 2, 3], color: '#fff' },
+          { name: 'Signal', data: [1, null, 2], color: '#0ff' },
+        ]}
+        guideLines={[{ value: 2, label: 'Neutral zone', color: '#888' }]}
+      />,
+    )
+
+    expect(screen.getByText('Neutral zone')).toBeInTheDocument()
+    expect(screen.getByText('MACD')).toBeInTheDocument()
+    expect(screen.getByText('Signal')).toBeInTheDocument()
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom/vitest'
+
+// Polyfill matchMedia for components that might rely on it during tests
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+/// <reference types="vitest" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,4 +39,13 @@ export default defineConfig({
     tailwindcss(),
     VitePWA(pwaOptions as Parameters<typeof VitePWA>[0]),
   ],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom, globals, and coverage reporting inside the Vite build
- add a shared test bootstrap that extends jest-dom matchers and polyfills matchMedia
- write initial LineChart interaction and rendering tests with Testing Library

## Testing
- npm test *(fails: vitest binary unavailable in container due to restricted package install)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b8863f2483208966bcd145e41133