### PR TITLE
Add tests for server push delivery and subscription store

### DIFF
--- a/server/__tests__/push-delivery.test.js
+++ b/server/__tests__/push-delivery.test.js
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('web-push', () => ({
+  default: {
+    sendNotification: vi.fn(),
+  },
+}))
+
+import webpush from 'web-push'
+import { broadcastNotification, normalizeNotificationPayload } from '../push-delivery.js'
+
+const subscription = {
+  endpoint: 'https://example.com/endpoint',
+  expirationTime: null,
+  keys: { p256dh: 'p256dh-key', auth: 'auth-key' },
+}
+
+describe('normalizeNotificationPayload', () => {
+  it('returns null for invalid input', () => {
+    expect(normalizeNotificationPayload(null)).toBeNull()
+    expect(normalizeNotificationPayload({})).toBeNull()
+    expect(normalizeNotificationPayload({ title: 'Only title' })).toBeNull()
+  })
+
+  it('keeps known fields and drops unknown ones', () => {
+    const payload = normalizeNotificationPayload({
+      title: 'Alert',
+      body: 'Price increased',
+      tag: 'btc',
+      icon: '/icon.png',
+      badge: '/badge.png',
+      renotify: true,
+      data: { symbol: 'BTC' },
+      extra: 'ignore-me',
+    })
+
+    expect(payload).toEqual({
+      title: 'Alert',
+      body: 'Price increased',
+      tag: 'btc',
+      icon: '/icon.png',
+      badge: '/badge.png',
+      renotify: true,
+      data: { symbol: 'BTC' },
+    })
+  })
+})
+
+describe('broadcastNotification', () => {
+  beforeEach(() => {
+    webpush.sendNotification.mockReset()
+  })
+
+  it('returns zero counts when there are no subscriptions', async () => {
+    const store = {
+      list: () => [],
+      remove: vi.fn(),
+    }
+
+    const result = await broadcastNotification(store, { title: 't', body: 'b' })
+
+    expect(result).toEqual({ delivered: 0, stale: 0 })
+    expect(webpush.sendNotification).not.toHaveBeenCalled()
+  })
+
+  it('delivers notifications to eligible subscriptions', async () => {
+    webpush.sendNotification.mockResolvedValue({ success: true })
+
+    const store = {
+      list: () => [
+        {
+          subscription,
+          filters: {
+            symbols: ['BTC'],
+            momentumTimeframes: ['15'],
+          },
+        },
+        {
+          subscription: { ...subscription, endpoint: 'https://example.com/other' },
+          filters: {
+            symbols: ['ETH'],
+          },
+        },
+      ],
+      remove: vi.fn(),
+    }
+
+    const notification = {
+      title: 'Momentum alert',
+      body: 'BTC gaining momentum',
+      data: {
+        symbol: 'btc',
+        type: 'momentum',
+        timeframes: ['15', '30'],
+      },
+    }
+
+    const result = await broadcastNotification(store, notification)
+
+    expect(result).toEqual({ delivered: 1, stale: 0 })
+    expect(webpush.sendNotification).toHaveBeenCalledTimes(1)
+    expect(webpush.sendNotification).toHaveBeenCalledWith(
+      subscription,
+      JSON.stringify(notification),
+      { TTL: 60 },
+    )
+  })
+
+  it('removes stale subscriptions and reports counts', async () => {
+    const error = new Error('Gone')
+    error.statusCode = 410
+    error.endpoint = 'https://example.com/stale'
+
+    webpush.sendNotification.mockRejectedValue(error)
+
+    const store = {
+      list: () => [
+        {
+          subscription: { ...subscription, endpoint: error.endpoint },
+          filters: undefined,
+        },
+      ],
+      remove: vi.fn().mockResolvedValue(true),
+    }
+
+    const result = await broadcastNotification(store, { title: 't', body: 'b' })
+
+    expect(result).toEqual({ delivered: 0, stale: 1 })
+    expect(store.remove).toHaveBeenCalledWith(error.endpoint)
+  })
+})

--- a/server/__tests__/push-subscription-store.test.js
+++ b/server/__tests__/push-subscription-store.test.js
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { PushSubscriptionStore } from '../push-subscription-store.js'
+
+const baseEntry = {
+  subscription: {
+    endpoint: 'https://example.com/endpoint',
+    expirationTime: null,
+    keys: { p256dh: 'p256dh', auth: 'auth' },
+  },
+  filters: {
+    symbols: ['BTC'],
+    momentumTimeframes: ['15'],
+  },
+}
+
+function cloneEntry() {
+  return {
+    subscription: {
+      endpoint: baseEntry.subscription.endpoint,
+      expirationTime: baseEntry.subscription.expirationTime,
+      keys: { ...baseEntry.subscription.keys },
+    },
+    filters: {
+      symbols: [...baseEntry.filters.symbols],
+      momentumTimeframes: [...baseEntry.filters.momentumTimeframes],
+    },
+  }
+}
+
+describe('PushSubscriptionStore', () => {
+  let tempDir
+  let filePath
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'push-store-'))
+    filePath = path.join(tempDir, 'subscriptions.json')
+  })
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('initializes empty store when file does not exist', async () => {
+    const store = new PushSubscriptionStore(filePath)
+    await store.init()
+
+    expect(store.list()).toEqual([])
+  })
+
+  it('upserts, persists and lists copies of subscriptions', async () => {
+    const store = new PushSubscriptionStore(filePath)
+    await store.init()
+
+    const entry = cloneEntry()
+    await store.upsert(entry)
+
+    const listed = store.list()
+    expect(listed).toHaveLength(1)
+    expect(listed[0]).toEqual(entry)
+
+    // Mutating the listed values should not change the internal state.
+    listed[0].subscription.endpoint = 'https://mutated'
+    listed[0].filters.symbols.push('ETH')
+
+    const freshList = store.list()
+    expect(freshList[0]).toEqual(entry)
+
+    // Data was persisted to disk and can be reloaded.
+    const nextStore = new PushSubscriptionStore(filePath)
+    await nextStore.init()
+
+    expect(nextStore.list()).toEqual([entry])
+  })
+
+  it('removes subscriptions by endpoint and reports status', async () => {
+    const store = new PushSubscriptionStore(filePath)
+    await store.init()
+
+    const entry = cloneEntry()
+    await store.upsert(entry)
+
+    const removed = await store.remove(entry.subscription.endpoint)
+    expect(removed).toBe(true)
+    expect(store.list()).toEqual([])
+
+    const removedMissing = await store.remove('https://example.com/missing')
+    expect(removedMissing).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add server-side tests covering push notification payload normalization and broadcast filtering
- exercise the push subscription store persistence workflow and ensure returned entries are defensive copies

## Testing
- npm test *(fails: local vitest binary missing because dependencies cannot be installed in this environment)*
- npx vitest run *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ddffacc883209752701a260ac04f