### PR TITLE
Add timeframe-specific ADX indicator below MACD chart

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -148,6 +148,13 @@ type DashboardViewProps = {
     histogram: Array<number | null>
     label: string
   }
+  adxSeries: {
+    adxLine: Array<number | null>
+    signalLine: Array<number | null>
+    plusDi: Array<number | null>
+    minusDi: Array<number | null>
+    label: string
+  }
   heatmapResults: HeatmapResult[]
   rsiLengthDescription: string
   rsiValues: Array<number | null>
@@ -230,6 +237,7 @@ export function DashboardView({
   onToggleMarketSummary,
   movingAverageSeries,
   macdSeries,
+  adxSeries,
   heatmapResults,
   rsiLengthDescription,
   rsiValues,
@@ -970,6 +978,17 @@ export function DashboardView({
                   { name: 'MACD', data: macdSeries.macdLine, color: '#60a5fa' },
                   { name: 'Signal', data: macdSeries.signalLine, color: '#f97316' },
                   { name: 'Histogram', data: macdSeries.histogram, color: '#34d399' },
+                ]}
+                isLoading={isFetching}
+              />
+              <LineChart
+                title={`ADX (${adxSeries.label})`}
+                labels={labels}
+                series={[
+                  { name: 'ADX', data: adxSeries.adxLine, color: '#facc15' },
+                  { name: 'Signal', data: adxSeries.signalLine, color: '#60a5fa' },
+                  { name: '+DI', data: adxSeries.plusDi, color: '#34d399' },
+                  { name: '-DI', data: adxSeries.minusDi, color: '#f87171' },
                 ]}
                 isLoading={isFetching}
               />


### PR DESCRIPTION
## Summary
- add timeframe-specific ADX settings and calculations alongside existing indicator utilities
- surface ADX data from the app state and render a dedicated chart with +DI/-DI and smoothed signal below MACD
- expose the new ADX readings throughout the dashboard view to complement existing momentum panels

## Testing
- npm run lint
- npm run test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ebd7fc608320a3b29f1987e2b08f