### PR TITLE
Fix heatmap URL fallback for dev

### DIFF
--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -32,6 +32,10 @@ function buildHeatmapUrl(symbol: string): URL {
       }
     }
 
+    if (import.meta.env.DEV && !rawBase && !apiBase) {
+      return new URL('http://localhost:4000/api/heatmap/snapshots')
+    }
+
     return new URL(DEFAULT_API_PATH, origin)
   })()
 


### PR DESCRIPTION
## Summary
- update the heatmap URL builder to target the local push server in development when no API base is configured

## Testing
- npm run dev:full *(fails: missing dependencies due to restricted npm registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68e502459cf88320a601c995effb363c