### PR TITLE
Adjust timeframe grid to display two cards per row

### DIFF
--- a/src/components/SignalsPanel.tsx
+++ b/src/components/SignalsPanel.tsx
@@ -271,7 +271,7 @@ export function SignalsPanel({ signals, snapshots, isLoading }: SignalsPanelProp
               )}
             </article>
           )}
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-3 sm:grid-cols-2">
             {TIMEFRAMES.map(({ value, label }) => {
               const snapshot = snapshotsByTimeframe.get(value)
 


### PR DESCRIPTION
## Summary
- update the signals panel timeframe grid so the cards render in two columns instead of up to three

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5056c464c83208ebb577f3b0b5dc7