### PR TITLE
Visualize Markov priors in signal overview cards

### DIFF
--- a/server/heatmap-service.js
+++ b/server/heatmap-service.js
@@ -156,6 +156,11 @@ function buildMockSnapshot(symbol, timeframe, label, template) {
       value: price * 0.985,
       slope: 12,
     },
+    markov: {
+      priorScore: 0,
+      currentState: null,
+      transitionMatrix: null,
+    },
   }
 }
 

--- a/src/components/signals/MarkovPriorGauge.tsx
+++ b/src/components/signals/MarkovPriorGauge.tsx
@@ -1,0 +1,72 @@
+import { Badge } from './Badge'
+import { formatSignedValue } from './utils'
+
+type MarkovPriorGaugeProps = {
+  priorScore: number
+  state: 'D' | 'R' | 'B' | 'U' | null
+}
+
+const STATE_LABEL: Record<'D' | 'R' | 'B' | 'U', string> = {
+  D: 'Downtrend',
+  R: 'Reversal',
+  B: 'Base',
+  U: 'Uptrend',
+}
+
+const STATE_BADGE_CLASS: Record<'bearish' | 'bullish' | 'neutral', string> = {
+  bearish: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+  bullish: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  neutral: 'border-slate-400/40 bg-slate-500/10 text-slate-200',
+}
+
+const PRIOR_DESCRIPTIONS = [
+  { threshold: 0.45, label: 'Strong bullish persistence' },
+  { threshold: 0.2, label: 'Bullish continuation tilt' },
+  { threshold: 0.05, label: 'Mild bullish lean' },
+  { threshold: -0.05, label: 'Balanced / indecisive' },
+  { threshold: -0.2, label: 'Mild bearish lean' },
+  { threshold: -0.45, label: 'Bearish continuation tilt' },
+  { threshold: -1, label: 'Strong bearish persistence' },
+]
+
+export function MarkovPriorGauge({ priorScore, state }: MarkovPriorGaugeProps) {
+  const normalized = Math.min(Math.max((priorScore + 1) / 2, 0), 1)
+  const pointerLeft = `${normalized * 100}%`
+  const priorScoreLabel = formatSignedValue(priorScore, 2)
+
+  const description = (() => {
+    for (const entry of PRIOR_DESCRIPTIONS) {
+      if (priorScore >= entry.threshold) {
+        return entry.label
+      }
+    }
+    return 'Balanced / indecisive'
+  })()
+
+  const badgeTone: 'bullish' | 'bearish' | 'neutral' =
+    priorScore > 0.05 ? 'bullish' : priorScore < -0.05 ? 'bearish' : 'neutral'
+
+  const stateLabel = state ? STATE_LABEL[state] ?? 'Unknown' : 'Unclassified'
+  const badgeClass = STATE_BADGE_CLASS[badgeTone]
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-900/40 p-4">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-slate-400">
+        <span>Markov prior</span>
+        <Badge className={badgeClass}>{stateLabel}</Badge>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="relative h-2 w-full rounded-full bg-gradient-to-r from-rose-500 via-slate-600 to-emerald-400">
+          <span
+            className="absolute top-1/2 h-3 w-0.5 rounded-full bg-white shadow-[0_0_6px_rgba(255,255,255,0.6)]"
+            style={{ left: pointerLeft, transform: 'translate(-50%, -50%)' }}
+          />
+        </div>
+        <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-slate-300">
+          <span>{description}</span>
+          <span className="font-mono text-xs text-slate-100">{priorScoreLabel}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/signals/TimeframeOverviewCard.tsx
+++ b/src/components/signals/TimeframeOverviewCard.tsx
@@ -1,5 +1,6 @@
 import { Badge } from './Badge'
 import { PercentageBar } from './PercentageBar'
+import { MarkovPriorGauge } from './MarkovPriorGauge'
 import {
   COMBINED_STRENGTH_GRADIENT,
   DIRECTION_BADGE_CLASS,
@@ -70,6 +71,10 @@ export function TimeframeOverviewCard({ snapshot }: TimeframeOverviewCardProps) 
     { label: 'EMA slow', value: formatPrice(breakdown.emaSlow, 5) },
     { label: 'MA long', value: formatPrice(breakdown.maLong, 5) },
   ]
+  const markovPriorScore = Number.isFinite(breakdown.markov.priorScore)
+    ? (breakdown.markov.priorScore as number)
+    : null
+  const markovState = breakdown.markov.currentState ?? null
 
   return (
     <article className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
@@ -111,6 +116,15 @@ export function TimeframeOverviewCard({ snapshot }: TimeframeOverviewCardProps) 
           ))}
         </div>
       </section>
+
+      {markovPriorScore != null && (
+        <section className="flex flex-col gap-3 text-xs text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+            Markov directional prior
+          </span>
+          <MarkovPriorGauge priorScore={markovPriorScore} state={markovState} />
+        </section>
+      )}
 
       <section className="flex flex-col gap-3 text-xs text-slate-200">
         <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">

--- a/src/lib/__tests__/signals.test.ts
+++ b/src/lib/__tests__/signals.test.ts
@@ -85,6 +85,11 @@ function createBaseHeatmapResult(overrides: Partial<HeatmapResult> = {}): Heatma
       value: null,
       slope: null,
     },
+    markov: {
+      priorScore: 0,
+      currentState: null,
+      transitionMatrix: null,
+    },
   }
 
   return {
@@ -105,6 +110,7 @@ function createBaseHeatmapResult(overrides: Partial<HeatmapResult> = {}): Heatma
     movingAverageCrosses:
       overrides.movingAverageCrosses ?? base.movingAverageCrosses,
     adx: { ...base.adx, ...(overrides.adx ?? {}) },
+    markov: { ...base.markov, ...(overrides.markov ?? {}) },
   }
 }
 
@@ -155,6 +161,8 @@ describe('getCombinedSignal', () => {
       rsiValue: 62,
       stochKValue: 72,
       signalStrength: 3,
+      signalStrengthRaw: 3,
+      markov: { priorScore: 0, currentState: null },
       label: 'STRONG_BUY',
     })
   })
@@ -183,6 +191,8 @@ describe('getCombinedSignal', () => {
       rsiValue: 40,
       stochKValue: 25,
       signalStrength: -3,
+      signalStrengthRaw: -3,
+      markov: { priorScore: 0, currentState: null },
       label: 'STRONG_SELL',
     })
   })
@@ -205,6 +215,8 @@ describe('getCombinedSignal', () => {
       trendStrength: 'Forming',
       adxIsRising: true,
       signalStrength: 2,
+      signalStrengthRaw: 2,
+      markov: { priorScore: 0, currentState: null },
       label: 'BUY_FORMING',
     })
   })
@@ -221,6 +233,8 @@ describe('getCombinedSignal', () => {
       adxDirection: 'NoConfirm',
       adxIsRising: false,
       signalStrength: 0,
+      signalStrengthRaw: 0,
+      markov: { priorScore: 0, currentState: null },
       label: 'NEUTRAL',
     })
   })

--- a/src/types/heatmap.ts
+++ b/src/types/heatmap.ts
@@ -43,6 +43,12 @@ export type MovingAverageCrossEvent = {
   direction: MovingAverageCrossDirection
 }
 
+export type MarkovContext = {
+  priorScore: number
+  currentState: 'D' | 'R' | 'B' | 'U' | null
+  transitionMatrix: number[][] | null
+}
+
 export type HeatmapResult = {
   entryTimeframe: string
   entryLabel: string
@@ -102,6 +108,7 @@ export type HeatmapResult = {
     value: number | null
     slope: number | null
   }
+  markov: MarkovContext
   adx?: {
     value: number | null
     plusDI: number | null

--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -18,7 +18,12 @@ export type CombinedSignalBreakdown = {
   emaFast: number | null
   emaSlow: number | null
   maLong: number | null
+  markov: {
+    priorScore: number
+    currentState: 'D' | 'R' | 'B' | 'U' | null
+  }
   signalStrength: number
+  signalStrengthRaw: number
   label:
     | 'STRONG_BUY'
     | 'BUY_FORMING'


### PR DESCRIPTION
## Summary
- add a MarkovPriorGauge component to render regime state, directional tilt, and score
- embed the gauge in each timeframe overview card so the Markov prior is visible alongside the combined signal details

## Testing
- npm test *(fails: vitest is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e62c03b1088320b06362db30575053