### PR TITLE
Add Markov multi-timeframe aggregation utilities

### DIFF
--- a/src/types/signals.ts
+++ b/src/types/signals.ts
@@ -132,3 +132,39 @@ export type TimeframeSignalSnapshot = {
   side: SignalDirection | null
   combined: CombinedSignal
 }
+
+export type MarkovTimeframeEvaluation = CombinedSignalBreakdown & {
+  timeframe: string
+  timeframeLabel: string
+}
+
+export type TrendMatrixRow = {
+  timeframe: string
+  timeframeLabel: string
+  bias: CombinedSignalBreakdown['bias']
+  rsi: number | null
+  stochK: number | null
+  adx: number | null
+  trend: CombinedSignalBreakdown['trendStrength']
+  adxDirection: CombinedSignalBreakdown['adxDirection']
+  prior: number | null
+  label: CombinedSignalBreakdown['label']
+  scoreRaw: number
+  score: number
+}
+
+export type AggregateMultiTfMarkovResult = {
+  combinedScore: number
+  combinedBias: {
+    dir: CombinedSignalDirection
+    strength: 'Strong' | 'Medium' | 'Weak' | 'Sideways'
+  }
+}
+
+export type MultiTimeframeModelSummary = {
+  perTimeframe: Record<string, MarkovTimeframeEvaluation>
+  trendMatrix: TrendMatrixRow[]
+  combined: AggregateMultiTfMarkovResult
+  qualifiedTimeframes: string[]
+  emitTradeSignal: boolean
+}


### PR DESCRIPTION
## Summary
- add Markov-aware evaluation and aggregation helpers for multi-timeframe modelling
- extend shared signal types to describe Markov trend matrix rows and combined summaries
- cover the new utilities with unit tests validating aggregation, gating, and model orchestration

## Testing
- npm run test -- --watch=false *(fails: vitest not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64df764e0832086b4f71cae337013